### PR TITLE
move from pyyaml to ruamel.yaml to avoid errors on dumping to yaml files

### DIFF
--- a/osde2e-wrapper.py
+++ b/osde2e-wrapper.py
@@ -28,7 +28,9 @@ import errno
 import git
 import shutil
 import threading
-import yaml
+from ruamel.yaml import YAML
+
+yaml = YAML()
 
 logging.basicConfig(level=logging.DEBUG,format='%(asctime)s.%(msecs)03d %(levelname)s %(module)s - %(funcName)s: %(message)s',datefmt='%Y-%m-%d %H:%M:%S')
 
@@ -184,7 +186,7 @@ def _watcher(osde2ectl_cmd,account_config,my_path,cluster_count,delay):
     logging.info('Getting status every %d seconds' % int(delay))
 
     yaml.dump(account_config,open(my_path + "/account_config.yaml",'w'))
-    my_config = yaml.safe_load(open(my_path + "/account_config.yaml"))
+    my_config = yaml.load(open(my_path + "/account_config.yaml"))
     my_thread = threading.currentThread()
     cmd = [osde2ectl_cmd, "list", "--custom-config", "account_config.yaml"]
 
@@ -338,7 +340,7 @@ def main():
 
     # load the account config yaml
     try:
-        account_config = yaml.safe_load(open(args.account_config))
+        account_config = yaml.load(open(args.account_config))
     except Exception as err:
         logging.error(err)
         logging.error('Failed to load account configuration yaml')

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ elasticsearch
 urllib3
 elasticsearch_dsl
 GitPython
-PyYAML
+ruamel.yaml


### PR DESCRIPTION
Related to https://github.com/yaml/pyyaml/issues/98

When dumping to yaml files, strings that could be considered numbers are not quoted.

Using ruamel.yaml, strings that could be numbers are correctly quoted