### PR TITLE
[WIP] Unique cluster name

### DIFF
--- a/osde2e-wrapper.py
+++ b/osde2e-wrapper.py
@@ -29,6 +29,8 @@ import git
 import shutil
 import threading
 import copy
+import string
+import random
 from ruamel.yaml import YAML
 
 yaml = YAML()
@@ -428,6 +430,11 @@ def main():
         while (loop_counter < args.cluster_count):
             create_cluster = False
             my_cluster_config = copy.deepcopy(account_config)
+            if "name" in account_config['cluster'].keys():
+                allowed_chars = string.ascii_lowercase + string.digits
+                random_string = ''.join(random.choice(
+                    allowed_chars) for j in range(5))
+                my_cluster_config['cluster']['name'] += "-" + random_string
             
             # if aws accounts were loaded from a file use them. if # of accounts given is less than the
             # requested amount of clusters loop back over it

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ urllib3
 elasticsearch_dsl
 GitPython
 ruamel.yaml
+copy


### PR DESCRIPTION
When creating clusters, if we have a name in the config file, all clusters are generated with the same name.

With this PR, cluster name from the config file will works as a seed, so definitive cluster name will be config[cluster][name]-random(5) to be aligned with the osde2e installation when no cluster name is selected as osde2e-random(5).

If no name is present on the config file, **perfscale** will be used as a seed.

We need unique names for clusters because this same name will be used as the thread name, so we can identify which thread is installing which cluster

