### PR TITLE
Switch from using a shallow to a deep copy for the account configuration

### DIFF
--- a/osde2e-wrapper.py
+++ b/osde2e-wrapper.py
@@ -28,6 +28,7 @@ import errno
 import git
 import shutil
 import threading
+import copy
 from ruamel.yaml import YAML
 
 yaml = YAML()
@@ -417,7 +418,7 @@ def main():
     try:
         while (loop_counter < args.cluster_count):
             create_cluster = False
-            my_cluster_config = account_config.copy()
+            my_cluster_config = copy.deepcopy(account_config)
             
             # if aws accounts were loaded from a file use them. if # of accounts given is less than the
             # requested amount of clusters loop back over it


### PR DESCRIPTION
When using account_config.copy() it was creating a shallow copy of the dictionary so any time we would make a change to the nested dictionary it would change it in every copy of the account_config. This would result in multiple used and mixed up account credentials when importing from an aws account file.

copy.deepcopy(account_config) makes a deep copy which includes all nested dictionaries as actual copies and not links.