### PR TITLE
Fixes ruamel crash while trying to dump the account config to a file

### DIFF
--- a/osde2e-wrapper.py
+++ b/osde2e-wrapper.py
@@ -31,7 +31,10 @@ import threading
 import copy
 from ruamel.yaml import YAML
 
-yaml = YAML()
+yaml = YAML(typ='safe')
+yaml.default_flow_style = False
+yaml.explicit_start = False
+yaml.allow_duplicate_keys = True
 
 def _connect_to_es(server, port, es_ssl):
     _es_connection_string = str(server) + ':' + str(port)

--- a/osde2e-wrapper.py
+++ b/osde2e-wrapper.py
@@ -31,11 +31,6 @@ import threading
 import copy
 from ruamel.yaml import YAML
 
-yaml = YAML(typ='safe')
-yaml.default_flow_style = False
-yaml.explicit_start = False
-yaml.allow_duplicate_keys = True
-
 def _connect_to_es(server, port, es_ssl):
     _es_connection_string = str(server) + ':' + str(port)
     if es_ssl == "true":
@@ -170,6 +165,11 @@ def _build_cluster(osde2e_cmnd,account_config,my_path,es,index,my_uuid,my_inc,ti
     # pass that dir as the cwd to subproccess
     cluster_path = my_path + "/" + str(my_inc)
     os.mkdir(cluster_path)
+    yaml = YAML(pure=True)
+    yaml.default_flow_style = False
+    yaml.explicit_start = False
+    yaml.explicit_end = False
+    yaml.allow_duplicate_keys = True
     yaml.dump(account_config,open(cluster_path + "/cluster_account.yaml",'w'))
     cluster_env = os.environ.copy()
     cluster_env["REPORT_DIR"] = cluster_path
@@ -189,7 +189,11 @@ def _build_cluster(osde2e_cmnd,account_config,my_path,es,index,my_uuid,my_inc,ti
 def _watcher(osde2ectl_cmd,account_config,my_path,cluster_count,delay):
     logging.info('Watcher thread started')
     logging.info('Getting status every %d seconds' % int(delay))
-
+    yaml = YAML(pure=True)
+    yaml.default_flow_style = False
+    yaml.explicit_start = False
+    yaml.explicit_end = False
+    yaml.allow_duplicate_keys = True
     yaml.dump(account_config,open(my_path + "/account_config.yaml",'w'))
     my_config = yaml.load(open(my_path + "/account_config.yaml"))
     my_thread = threading.currentThread()
@@ -326,7 +330,7 @@ def main():
         default='INFO',
         help='Log level to show')
     parser.add_argument(
-       '--dry-run',
+        '--dry-run',
         dest='dry_run',
         action='store_true',
         help='Perform a dry-run of the script without creating any cluster')
@@ -374,6 +378,7 @@ def main():
 
     # load the account config yaml
     try:
+        yaml = YAML(pure=True)
         account_config = yaml.load(open(args.account_config))
     except Exception as err:
         logging.error(err)


### PR DESCRIPTION
After the switch to ruamel we would inconsistently get a crash from ruamel that ended with this emitter error:

```
ruamel.yaml.emitter.EmitterError: expected NodeEvent, but got StreamEndEvent()
    raise EmitterError('expected DocumentEndEvent, but got %s' % (self.event,))
ruamel.yaml.emitter.EmitterError: expected DocumentEndEvent, but got MappingStartEvent(anchor=None, tag='tag:yaml.org,2002:map', implicit=True, flow_style=False)
```

Adding the additional yaml options
```
yaml = YAML(typ='safe')
yaml.default_flow_style = False
yaml.explicit_start = False
yaml.allow_duplicate_keys = True
```

Resolved the issue and I could successfully test with 1000 unique accounts without a crash.