### PR TITLE
adding cluster expiration parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ without uploading any information**
 | --batch-size | Number of clusters to create in a batch. If not set it will try and create them all at once. <br>**NOTE**: If not used in conjunction with --delay-between-batch the cluster creation will block at the set batch size until one completes then continue. I.e. if 3 clusters are requested with a batch size of 2. The first two will be requested and then it will block until one of those completes to request the third. | -- |
 | --delay-between-batch | If set, we will wait X seconds between each batch request | -- |
 | --watcher-delay | Delay between each status check in seconds. | 60 |
+| --expire | Minutes until cluster expires and it is deleted by OSD. It sets CLUSTER_EXPIRY_IN_MINUTES var for osde2e | -- |
 | --cleanup-clusters | Cleanup any non-error state clusters upon test completion. | True |
 | --user-override | User to set as the owner. <br>**NOTE: this takes precidence over what is provided in the account-config file** | -- |
 | --aws-account-file | AWS account file that provides account,accessKey,secretKey. This file will be looped over as needed to achieve all clusters requested. Example format: <br> ```0009808111,AAAA53YREVPCS111,00019ILbzo+yWU9C5FG5YrnoZC5eBg2111```<br>```0007006111,AAAAUZRL736SW6111,000P/b94AL+LSCzJBWbZCYRuYArF9Zr111``` | -- |
@@ -116,7 +117,7 @@ This can quickly lead to resource constraint if not planned accordingly.
 ### Memory
 
 While not inately memory instensive itself, the wrapper does call osde2e for each cluster installation. Because of
-this, a system can find itself with memory pressure if running a large number of installations. 
+this, a system can find itself with memory pressure if running a large number of installations.
 
 ### Max open file limits
 

--- a/osde2e-wrapper.py
+++ b/osde2e-wrapper.py
@@ -172,6 +172,8 @@ def _build_cluster(osde2e_cmnd,account_config,my_path,es,index,my_uuid,my_inc,ti
     yaml.dump(account_config,open(cluster_path + "/cluster_account.yaml",'w'))
     cluster_env = os.environ.copy()
     cluster_env["REPORT_DIR"] = cluster_path
+    if account_config['ocm']['expiration']:
+        cluster_env["CLUSTER_EXPIRY_IN_MINUTES"] = str(account_config['ocm']['expiration'])
     logging.info('Attempting cluster installation')
     logging.info('Output directory set to %s' % cluster_path)
     cluster_cmd = [osde2e_cmnd, "test","--custom-config", "cluster_account.yaml"]
@@ -306,6 +308,10 @@ def main():
         type=int,
         help='Delay between each status check')
     parser.add_argument(
+        '--expire',
+        type=int,
+        help='Minutes until cluster expires and it is deleted by OSD')
+    parser.add_argument(
         '--cleanup-clusters',
         default=True,
         help='Cleanup any non-error state clusters upon test completion')
@@ -399,6 +405,10 @@ def main():
     elif "userOverride" not in account_config['ocm'].keys():
         account_config['ocm']['userOverride'] = str(uuid.uuid4())[:8]
     logging.info('User override set to: %s' % account_config['ocm']['userOverride'])
+
+    if args.expire is not None:
+        account_config['ocm']['expiration'] = args.expire
+        logging.info('Setting cluster expiration time to: %d' % args.expire)
 
     cmnd_path = _verify_cmnd(args.command,my_path) if not args.dry_run else ""
 


### PR DESCRIPTION
osde2e have an option to increase the expiration time of a cluster installed on OCM, using the env var CLUSTER_EXPIRY_IN_MINUTES.

This PR adds an argument to the wrapper to set that var when trigger the installation using osde2e.

parameter is required to be an integer, which is verified by the argparse module, so it is not necessary to include more logic about correct values accepted.