### PR TITLE
retrieve kubeconfig file after each cluster installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ osde2e and osde2ectl utilities.
 It will download the latest osde2e bits from github, compile the go code, execute the build
 of X clusters with a range of options, monitor the installation/ready status of the clusters,
 upload the resultant timeing data that is provided into Elasticsearch and then cleanup any
-non-errored clusters. Errored clusters are left to allow additional diagnosis
+non-errored clusters. Errored clusters are left to allow additional diagnosis.
+After each cluster installation, kubeconfig file for that cluster will be downloaded and located
+on its own folder.
 
 Example invocation:
 

--- a/osde2e-wrapper.py
+++ b/osde2e-wrapper.py
@@ -141,7 +141,29 @@ def _verify_cmnd(osde2e_cmnd,my_path):
 
     return osde2e_cmnd
 
-def _build_cluster(osde2e_cmnd,account_config,my_path,es,index,my_uuid,my_inc,dry_run):
+def _download_kubeconfig(osde2ectl_cmd,my_path):
+    logging.info('Attempting to load metadata json')
+    try:
+        metadata = json.load(open(my_path + "/metadata.json"))
+        cluster_id = metadata['cluster-id']
+    except Exception as err:
+        logging.error(err)
+        logging.error('Failed to load metadata.json file located %s, kubeconfig file wont be downloaded' % my_path)
+        return 0
+
+    # required to create a new folder on kubeconfig_path until https://github.com/openshift/osde2e/issues/657 will be fixed
+    kubeconfig_path = my_path + "/" + cluster_id
+    logging.info('Downloading kubeconfig file for cluster %s on %s' % (cluster_id,kubeconfig_path))
+    cmd = [osde2ectl_cmd, "--custom-config", "cluster_account.yaml", "get", "-k", "-i", cluster_id, "--kube-config-path", kubeconfig_path]
+    logging.debug(cmd)
+    process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,cwd=my_path,universal_newlines=True)
+    stdout,stderr = process.communicate()
+    if process.returncode != 0:
+        logging.error('Failed to download kubeconfig file for cluster id %s with this stdout/stderr:' % cluster_id)
+        logging.error(stdout)
+        logging.error(stderr)
+
+def _build_cluster(osde2e_cmnd,osde2ectl_cmd,account_config,my_path,es,index,my_uuid,my_inc,timestamp,dry_run):
     cluster_start_time = time.strftime("%Y-%m-%dT%H:%M:%S")
     success = True
 
@@ -188,11 +210,12 @@ def _build_cluster(osde2e_cmnd,account_config,my_path,es,index,my_uuid,my_inc,dr
         except Exception as err:
             logging.error(err)
             logging.error('Failed to write metadata.json file located %s' % cluster_path)
+        _download_kubeconfig(osde2ectl_cmd, cluster_path)
         if es is not None:
             metadata["timestamp"] = time.strftime("%Y-%m-%dT%H:%M:%S")
             _index_result(es,index,metadata)
 
-def _watcher(osde2ectl_cmd,account_config,my_path,cluster_count,delay):
+def _watcher(osde2ectl_cmd,account_config,my_path,cluster_count,delay,my_uuid):
     logging.info('Watcher thread started')
     logging.info('Getting status every %d seconds' % int(delay))
     yaml = YAML(pure=True)
@@ -228,6 +251,7 @@ def _watcher(osde2ectl_cmd,account_config,my_path,cluster_count,delay):
                     error.append(line.split()[1])
                     logging.debug(line.split()[1])
 
+        logging.info('Requested Clusters for test %s: %d' % (my_uuid,cluster_count))
         if cluster_count != 0:
             logging.debug(state.items())
             logging.debug(status.items())
@@ -408,13 +432,23 @@ def main():
     my_path = args.path
     if my_path is None:
         my_path = '/tmp/' + my_uuid
-    logging.info('Using %s as temp directory' % (my_path))
+    logging.info('Using %s as working directory' % (my_path))
     _create_path(my_path)
 
     if os.path.exists(args.account_config):
         logging.debug('Account configuration file exists')
     else:
         logging.error('Account configuration file not found at %s' % args.account_config)
+        exit(1)
+
+    try:
+        logging.debug('Saving test UUID to the working directory')
+        uuid_file = open(my_path + '/uuid','x')
+        uuid_file.write(my_uuid)
+        uuid_file.close()
+    except Exception as err:
+        logging.debug('Cannot write file %s/uuid' % my_path)
+        logging.error(err)
         exit(1)
 
     # load the account config yaml
@@ -451,7 +485,7 @@ def main():
     # launch watcher thread to report status
     if not args.dry_run:
         logging.info('Launching watcher thread')
-        watcher = threading.Thread(target=_watcher,args=(cmnd_path + "/osde2ectl",account_config,my_path,args.cluster_count,args.watcher_delay))
+        watcher = threading.Thread(target=_watcher,args=(cmnd_path + "/osde2ectl",account_config,my_path,args.cluster_count,args.watcher_delay,my_uuid))
         watcher.daemon = True
         watcher.start()
         logging.info('Attempting to start %d clusters with %d batch size' % (args.cluster_count,args.batch_size))
@@ -519,7 +553,8 @@ def main():
             if create_cluster:
                 logging.debug('Starting Cluster thread %d' % (loop_counter + 1))
                 try:
-                    thread = threading.Thread(target=_build_cluster,args=(cmnd_path + "/osde2e",my_cluster_config,my_path,es,args.index,my_uuid,loop_counter,args.dry_run))
+                    timestamp = time.strftime("%Y-%m-%dT%H:%M:%S")
+                    thread = threading.Thread(target=_build_cluster,args=(cmnd_path + "/osde2e", cmnd_path + "/osde2ectl", my_cluster_config,my_path,es,args.index,my_uuid,loop_counter,timestamp,args.dry_run))
                 except Exception as err:
                     logging.error(err)
                 cluster_thread_list.append(thread)


### PR DESCRIPTION
After each cluster is installed, kubeconfig file will be downloaded and stored inside the cluster folder, with the rest of the files, creating a new directory for it until [issue on osde2e](https://github.com/openshift/osde2e/issues/657) will be fixed.



```
2020-12-15 16:17:25.794 INFO osde2e-wrapper - _download_kubeconfig: Attempting to load metadata json
2020-12-15 16:17:25.796 INFO osde2e-wrapper - _download_kubeconfig: Downloading kubeconfig file for cluster 1hj6bn6h2qfo4v54cjqkhvv8ds2a7kn6 on /tmp/8a1c5138-e6ac-4e38-a51d-9dec20eba111/1/1hj6bn6h2qfo4v54cjqkhvv8ds2a7kn6
2020-12-15 16:17:25.796 INFO osde2e-wrapper - _download_kubeconfig: Attempting to load metadata json
2020-12-15 16:17:25.802 INFO osde2e-wrapper - _download_kubeconfig: Downloading kubeconfig file for cluster 1hj6bn0sr1tmsa22utah9d73k9e4a7p3 on /tmp/8a1c5138-e6ac-4e38-a51d-9dec20eba111/2/1hj6bn0sr1tmsa22utah9d73k9e4a7p3
2020-12-15 16:17:39.724 INFO osde2e-wrapper - _watcher: Watcher exiting
```

```
$ cd /tmp/8a1c5138-e6ac-4e38-a51d-9dec20eba111/
[morenod@morenod-laptop 8a1c5138-e6ac-4e38-a51d-9dec20eba111]$ ls -l 1/
1hj6bn6h2qfo4v54cjqkhvv8ds2a7kn6/               cluster_account.yaml                            install/                                        test_output.log
1hj6bn6h2qfo4v54cjqkhvv8ds2a7kn6..metrics.prom  custom-prow-metadata.json                       metadata.json                                   
[morenod@morenod-laptop 8a1c5138-e6ac-4e38-a51d-9dec20eba111]$ ls -l 1/1hj6bn6h2qfo4v54cjqkhvv8ds2a7kn6/
total 12
-rwxrwxr-x. 1 morenod morenod 8975 dic 15 16:17 osde2e-hsxri-kubeconfig.txt
[morenod@morenod-laptop 8a1c5138-e6ac-4e38-a51d-9dec20eba111]$ ls -l 2/
1hj6bn0sr1tmsa22utah9d73k9e4a7p3/               cluster_account.yaml                            install/                                        test_output.log
1hj6bn0sr1tmsa22utah9d73k9e4a7p3..metrics.prom  custom-prow-metadata.json                       metadata.json                                   
[morenod@morenod-laptop 8a1c5138-e6ac-4e38-a51d-9dec20eba111]$ ls -l 2/1hj6bn0sr1tmsa22utah9d73k9e4a7p3/
total 12
-rwxrwxr-x. 1 morenod morenod 8975 dic 15 16:17 osde2e-e0ok9-kubeconfig.txt

```
