### PR TITLE
correct expiration key findind when it is not present on the file

### DIFF
--- a/osde2e-wrapper.py
+++ b/osde2e-wrapper.py
@@ -172,7 +172,7 @@ def _build_cluster(osde2e_cmnd,account_config,my_path,es,index,my_uuid,my_inc,ti
     yaml.dump(account_config,open(cluster_path + "/cluster_account.yaml",'w'))
     cluster_env = os.environ.copy()
     cluster_env["REPORT_DIR"] = cluster_path
-    if account_config['ocm']['expiration']:
+    if "expiration" in account_config['ocm'].keys():
         cluster_env["CLUSTER_EXPIRY_IN_MINUTES"] = str(account_config['ocm']['expiration'])
     logging.info('Attempting cluster installation')
     logging.info('Output directory set to %s' % cluster_path)


### PR DESCRIPTION
Current definition only works when account_config['ocm']['expiration'] exists.

if not, it will fail with following error:

```
Exception in thread Thread-2:
Traceback (most recent call last):
  File "/usr/lib64/python3.9/threading.py", line 950, in _bootstrap_inner
Exception in thread Thread-3:
Traceback (most recent call last):
  File "/usr/lib64/python3.9/threading.py", line 950, in _bootstrap_inner
    self.run()
  File "/usr/lib64/python3.9/threading.py", line 888, in run
    self.run()
  File "/usr/lib64/python3.9/threading.py", line 888, in run
    self._target(*self._args, **self._kwargs)
  File "/home/morenod/osd/osde2e-scale-wrapper/osde2e-wrapper.py", line 159, in _build_cluster
    self._target(*self._args, **self._kwargs)
  File "/home/morenod/osd/osde2e-scale-wrapper/osde2e-wrapper.py", line 159, in _build_cluster
    if account_config['ocm']['expiration'] is not None:
  File "/home/morenod/.local/lib/python3.9/site-packages/ruamel/yaml/comments.py", line 753, in __getitem__
    if account_config['ocm']['expiration'] is not None:
  File "/home/morenod/.local/lib/python3.9/site-packages/ruamel/yaml/comments.py", line 753, in __getitem__
    return ordereddict.__getitem__(self, key)
    return ordereddict.__getitem__(self, key)
KeyError: 'expiration'
KeyError: 'expiration'
```

New definition search for the key so if it is not present, it wont fail