### PR TITLE
move some outputs to debug

### DIFF
--- a/osde2e-wrapper.py
+++ b/osde2e-wrapper.py
@@ -224,14 +224,19 @@ def _watcher(osde2ectl_cmd,account_config,my_path,cluster_count,delay):
                     error.append(line.split()[1])
                     logging.debug(line.split()[1])
 
-        logging.info('Requested Clusters: %d' % cluster_count)
         if cluster_count != 0:
-            logging.info('Current state counts:')
-            logging.info(state.items())
-            logging.info('Current status counts:')
-            logging.info(status.items())
-            logging.info('Clusters in error state:')
-            logging.info(error)
+            logging.debug(state.items())
+            logging.debug(status.items())
+            state_output = "Current clusters state: " + str(cluster_count) + " clusters"
+            status_output = "Current clusters status: " + str(cluster_count) + " clusters"
+            for i1 in state.items():
+                state_output += " (" + str(i1[0]) + ": " + str(i1[1]) + ")"
+            for i2 in status.items():
+                status_output += " (" + str(i2[0]) + ": " + str(i2[1]) + ")"
+            logging.info(state_output)
+            logging.info(status_output)
+            if error:
+                logging.warning('Clusters in error state: %s' % error)
 
         time.sleep(delay)
     logging.info('Watcher exiting')

--- a/osde2e-wrapper.py
+++ b/osde2e-wrapper.py
@@ -174,11 +174,12 @@ def _build_cluster(osde2e_cmnd,account_config,my_path,es,index,my_uuid,my_inc,ti
     cluster_env["REPORT_DIR"] = cluster_path
     if "expiration" in account_config['ocm'].keys():
         cluster_env["CLUSTER_EXPIRY_IN_MINUTES"] = str(account_config['ocm']['expiration'])
-    logging.info('Attempting cluster installation')
-    logging.info('Output directory set to %s' % cluster_path)
+    logging.debug('Attempting cluster installation')
+    logging.debug('Output directory set to %s' % cluster_path)
     cluster_cmd = [osde2e_cmnd, "test","--custom-config", "cluster_account.yaml"]
     if not dry_run:
         process = subprocess.Popen(cluster_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=cluster_env, cwd=cluster_path)
+        logging.info('Started cluster %d' % my_inc)
         stdout,stderr = process.communicate()
         if process.returncode != 0:
             logging.error('Failed to build cluster number %d' % my_inc)
@@ -482,7 +483,7 @@ def main():
                 create_cluster = True
 
             if create_cluster:
-                logging.info('Starting Cluster thread %d' % (loop_counter + 1))
+                logging.debug('Starting Cluster thread %d' % (loop_counter + 1))
                 try:
                     thread = threading.Thread(target=_build_cluster,args=(cmnd_path + "/osde2e",my_cluster_config,my_path,es,args.index,my_uuid,loop_counter,timestamp,args.dry_run))
                 except Exception as err:
@@ -496,7 +497,7 @@ def main():
         logging.error('Thread creation failed')
 
     # Wait for active threads to finish
-    logging.info('All clusters requested. Waiting for them to finish')
+    logging.info('All clusters (%d) requested. Waiting for them to finish' % len(cluster_thread_list))
     for t in cluster_thread_list:
         try:
             t.join()


### PR DESCRIPTION
Info execution:

```
$ python3 osde2e-scale-wrapper/osde2e-wrapper.py --account-config /home/morenod/osd/custom_config.yaml --cluster-count 10 --command /home/morenod/osd/osde2e/out --log-level info
2021-01-05 12:47:32.004 INFO osde2e-wrapper - main: Logging to console
2021-01-05 12:47:32.005 INFO osde2e-wrapper - main: Test running with UUID: 7d019831-f064-45e3-ab6b-0ca427c1ad96
2021-01-05 12:47:32.005 INFO osde2e-wrapper - main: Using /tmp/7d019831-f064-45e3-ab6b-0ca427c1ad96 as temp directory
2021-01-05 12:47:32.005 INFO osde2e-wrapper - _create_path: Create directory /tmp/7d019831-f064-45e3-ab6b-0ca427c1ad96 if it does not exist
2021-01-05 12:47:32.014 INFO osde2e-wrapper - main: User override set to: dsanzmor
2021-01-05 12:47:32.014 INFO osde2e-wrapper - _verify_cmnd: Testing osde2e command with: osde2e -h
2021-01-05 12:47:32.166 INFO osde2e-wrapper - _verify_cmnd: osde2e and osde2ectl commands validated with -h. Directory is /home/morenod/osd/osde2e/out
2021-01-05 12:47:32.167 INFO osde2e-wrapper - main: Launching watcher thread
2021-01-05 12:47:32.167 INFO osde2e-wrapper - _watcher: Watcher thread started
2021-01-05 12:47:32.167 INFO osde2e-wrapper - _watcher: Getting status every 60 seconds
2021-01-05 12:47:32.167 INFO osde2e-wrapper - main: Attempting to start 10 clusters with 0 batch size
2021-01-05 12:47:32.182 INFO osde2e-wrapper - _build_cluster: Started cluster 1
2021-01-05 12:47:32.219 INFO osde2e-wrapper - main: All clusters (10) requested. Waiting for them to finish
2021-01-05 12:47:32.257 INFO osde2e-wrapper - _build_cluster: Started cluster 3
2021-01-05 12:47:32.264 INFO osde2e-wrapper - _build_cluster: Started cluster 2
2021-01-05 12:47:32.297 INFO osde2e-wrapper - _build_cluster: Started cluster 7
2021-01-05 12:47:32.336 INFO osde2e-wrapper - _build_cluster: Started cluster 6
2021-01-05 12:47:32.342 INFO osde2e-wrapper - _build_cluster: Started cluster 10
2021-01-05 12:47:32.350 INFO osde2e-wrapper - _build_cluster: Started cluster 4
2021-01-05 12:47:32.356 INFO osde2e-wrapper - _build_cluster: Started cluster 5
2021-01-05 12:47:32.357 INFO osde2e-wrapper - _build_cluster: Started cluster 9
2021-01-05 12:47:32.366 INFO osde2e-wrapper - _build_cluster: Started cluster 8
2021-01-05 12:47:40.484 INFO osde2e-wrapper - _watcher: Requested Clusters: 10
2021-01-05 12:47:40.484 INFO osde2e-wrapper - _watcher: Current state counts:
2021-01-05 12:47:40.484 INFO osde2e-wrapper - _watcher: dict_items([('installing', 10)])
2021-01-05 12:47:40.485 INFO osde2e-wrapper - _watcher: Current status counts:
2021-01-05 12:47:40.485 INFO osde2e-wrapper - _watcher: dict_items([('waiting-for-ready', 10)])
2021-01-05 12:47:40.485 INFO osde2e-wrapper - _watcher: Clusters in error state:
2021-01-05 12:47:40.485 INFO osde2e-wrapper - _watcher: []
2021-01-05 12:48:51.908 INFO osde2e-wrapper - _watcher: Requested Clusters: 20
2021-01-05 12:48:51.908 INFO osde2e-wrapper - _watcher: Current state counts:
2021-01-05 12:48:51.909 INFO osde2e-wrapper - _watcher: dict_items([('installing', 18), ('pending', 2)])
2021-01-05 12:48:51.909 INFO osde2e-wrapper - _watcher: Current status counts:
2021-01-05 12:48:51.909 INFO osde2e-wrapper - _watcher: dict_items([('waiting-for-ready', 20)])
2021-01-05 12:48:51.909 INFO osde2e-wrapper - _watcher: Clusters in error state:
2021-01-05 12:48:51.909 INFO osde2e-wrapper - _watcher: []
```

Debug execution:

```$ python3 osde2e-scale-wrapper/osde2e-wrapper.py --account-config /home/morenod/osd/custom_config.yaml --cluster-count 10 --command /home/morenod/osd/osde2e/out --log-level debug
2021-01-05 13:00:44.966 INFO osde2e-wrapper - main: Logging to console
2021-01-05 13:00:44.966 INFO osde2e-wrapper - main: Test running with UUID: 3067cac4-cbb5-4f7f-a3ab-6a06a7db052a
2021-01-05 13:00:44.966 INFO osde2e-wrapper - main: Using /tmp/3067cac4-cbb5-4f7f-a3ab-6a06a7db052a as temp directory
2021-01-05 13:00:44.966 INFO osde2e-wrapper - _create_path: Create directory /tmp/3067cac4-cbb5-4f7f-a3ab-6a06a7db052a if it does not exist
2021-01-05 13:00:44.967 DEBUG osde2e-wrapper - main: Account configuration file exists
2021-01-05 13:00:44.974 INFO osde2e-wrapper - main: User override set to: dsanzmor
2021-01-05 13:00:44.974 INFO osde2e-wrapper - _verify_cmnd: Testing osde2e command with: osde2e -h
2021-01-05 13:00:45.085 INFO osde2e-wrapper - _verify_cmnd: osde2e and osde2ectl commands validated with -h. Directory is /home/morenod/osd/osde2e/out
2021-01-05 13:00:45.085 INFO osde2e-wrapper - main: Launching watcher thread
2021-01-05 13:00:45.086 INFO osde2e-wrapper - _watcher: Watcher thread started
2021-01-05 13:00:45.086 INFO osde2e-wrapper - main: Attempting to start 10 clusters with 0 batch size
2021-01-05 13:00:45.086 INFO osde2e-wrapper - _watcher: Getting status every 60 seconds
2021-01-05 13:00:45.086 DEBUG osde2e-wrapper - main: Starting Cluster thread 2
2021-01-05 13:00:45.087 DEBUG osde2e-wrapper - main: Number of alive threads 3
2021-01-05 13:00:45.087 DEBUG osde2e-wrapper - main: Starting Cluster thread 3
2021-01-05 13:00:45.088 DEBUG osde2e-wrapper - main: Number of alive threads 4
2021-01-05 13:00:45.088 DEBUG osde2e-wrapper - main: Starting Cluster thread 4
2021-01-05 13:00:45.089 DEBUG osde2e-wrapper - main: Number of alive threads 5
2021-01-05 13:00:45.090 DEBUG osde2e-wrapper - main: Starting Cluster thread 5
2021-01-05 13:00:45.090 DEBUG osde2e-wrapper - main: Number of alive threads 6
2021-01-05 13:00:45.091 DEBUG osde2e-wrapper - main: Starting Cluster thread 6
2021-01-05 13:00:45.091 DEBUG osde2e-wrapper - main: Number of alive threads 7
2021-01-05 13:00:45.092 DEBUG osde2e-wrapper - main: Starting Cluster thread 7
2021-01-05 13:00:45.116 DEBUG osde2e-wrapper - _build_cluster: Attempting cluster installation
2021-01-05 13:00:45.116 DEBUG osde2e-wrapper - _build_cluster: Output directory set to /tmp/3067cac4-cbb5-4f7f-a3ab-6a06a7db052a/5
2021-01-05 13:00:45.117 DEBUG osde2e-wrapper - main: Number of alive threads 8
2021-01-05 13:00:45.118 DEBUG osde2e-wrapper - main: Starting Cluster thread 8
2021-01-05 13:00:45.123 DEBUG osde2e-wrapper - main: Number of alive threads 9
2021-01-05 13:00:45.124 DEBUG osde2e-wrapper - main: Starting Cluster thread 9
2021-01-05 13:00:45.130 DEBUG osde2e-wrapper - main: Number of alive threads 10
2021-01-05 13:00:45.131 DEBUG osde2e-wrapper - main: Starting Cluster thread 10
2021-01-05 13:00:45.137 INFO osde2e-wrapper - _build_cluster: Started cluster 5
2021-01-05 13:00:45.137 DEBUG osde2e-wrapper - _build_cluster: Attempting cluster installation
2021-01-05 13:00:45.141 DEBUG osde2e-wrapper - _watcher: ['/home/morenod/osd/osde2e/out/osde2ectl', 'list', '--custom-config', 'account_config.yaml']
2021-01-05 13:00:45.149 DEBUG osde2e-wrapper - _build_cluster: Attempting cluster installation
2021-01-05 13:00:45.150 DEBUG osde2e-wrapper - main: Number of alive threads 11
2021-01-05 13:00:45.155 DEBUG osde2e-wrapper - _build_cluster: Attempting cluster installation
2021-01-05 13:00:45.160 DEBUG osde2e-wrapper - _build_cluster: Attempting cluster installation
2021-01-05 13:00:45.165 DEBUG osde2e-wrapper - _build_cluster: Attempting cluster installation
2021-01-05 13:00:45.171 DEBUG osde2e-wrapper - _build_cluster: Output directory set to /tmp/3067cac4-cbb5-4f7f-a3ab-6a06a7db052a/3
2021-01-05 13:00:45.172 DEBUG osde2e-wrapper - _build_cluster: Output directory set to /tmp/3067cac4-cbb5-4f7f-a3ab-6a06a7db052a/7
2021-01-05 13:00:45.178 DEBUG osde2e-wrapper - _build_cluster: Attempting cluster installation
2021-01-05 13:00:45.178 DEBUG osde2e-wrapper - _build_cluster: Attempting cluster installation
2021-01-05 13:00:45.179 DEBUG osde2e-wrapper - main: Starting Cluster thread 11
2021-01-05 13:00:45.179 DEBUG osde2e-wrapper - _build_cluster: Output directory set to /tmp/3067cac4-cbb5-4f7f-a3ab-6a06a7db052a/1
2021-01-05 13:00:45.181 DEBUG osde2e-wrapper - _build_cluster: Output directory set to /tmp/3067cac4-cbb5-4f7f-a3ab-6a06a7db052a/4
2021-01-05 13:00:45.181 DEBUG osde2e-wrapper - _build_cluster: Output directory set to /tmp/3067cac4-cbb5-4f7f-a3ab-6a06a7db052a/2
2021-01-05 13:00:45.182 DEBUG osde2e-wrapper - _build_cluster: Output directory set to /tmp/3067cac4-cbb5-4f7f-a3ab-6a06a7db052a/6
2021-01-05 13:00:45.194 DEBUG osde2e-wrapper - _build_cluster: Output directory set to /tmp/3067cac4-cbb5-4f7f-a3ab-6a06a7db052a/8
2021-01-05 13:00:45.198 DEBUG osde2e-wrapper - main: Number of alive threads 12
2021-01-05 13:00:45.241 INFO osde2e-wrapper - main: All clusters (10) requested. Waiting for them to finish
2021-01-05 13:00:45.206 INFO osde2e-wrapper - _build_cluster: Started cluster 7
2021-01-05 13:00:45.207 DEBUG osde2e-wrapper - _build_cluster: Attempting cluster installation
2021-01-05 13:00:45.245 DEBUG osde2e-wrapper - _build_cluster: Output directory set to /tmp/3067cac4-cbb5-4f7f-a3ab-6a06a7db052a/9
2021-01-05 13:00:45.201 INFO osde2e-wrapper - _build_cluster: Started cluster 3
2021-01-05 13:00:45.244 DEBUG osde2e-wrapper - _build_cluster: Attempting cluster installation
2021-01-05 13:00:45.251 DEBUG osde2e-wrapper - _build_cluster: Output directory set to /tmp/3067cac4-cbb5-4f7f-a3ab-6a06a7db052a/10
2021-01-05 13:00:45.245 INFO osde2e-wrapper - _build_cluster: Started cluster 4
2021-01-05 13:00:45.219 INFO osde2e-wrapper - _build_cluster: Started cluster 1
2021-01-05 13:00:45.249 INFO osde2e-wrapper - _build_cluster: Started cluster 8
2021-01-05 13:00:45.250 INFO osde2e-wrapper - _build_cluster: Started cluster 6
2021-01-05 13:00:45.245 INFO osde2e-wrapper - _build_cluster: Started cluster 2
2021-01-05 13:00:45.273 INFO osde2e-wrapper - _build_cluster: Started cluster 9
2021-01-05 13:00:45.291 INFO osde2e-wrapper - _build_cluster: Started cluster 10
2021-01-05 13:00:51.706 INFO osde2e-wrapper - _watcher: Requested Clusters: 7
```