### PR TITLE
make account config parameter optional when index-only is selected

### DIFF
--- a/osde2e-wrapper.py
+++ b/osde2e-wrapper.py
@@ -300,6 +300,9 @@ def _cleanup_clusters(osde2ectl_cmd,my_path,account_config):
 def main():
     parser = argparse.ArgumentParser(description="osde2e wrapper script")
     parser.add_argument(
+        '--account-config',
+        help='Yaml account config')
+    parser.add_argument(
         '--es-url',
         help='Provide ES connection URL')
     parser.add_argument(
@@ -330,10 +333,6 @@ def main():
     parser.add_argument(
         '--path',
         help='Path to save temporary data')
-    parser.add_argument(
-        '--account-config',
-        required=True,
-        help='Yaml account config')
     parser.add_argument(
         '--cleanup',
         help='Should we delete the temporary directory',
@@ -386,6 +385,9 @@ def main():
         action='store_true',
         help='Perform a dry-run of the script without creating any cluster')
     args = parser.parse_args()
+
+    if not args.es_index_only and not args.account_config:
+        parser.error('the following arguments are required: --account-config')
 
     if args.es_url is not None:
         es = _connect_to_es(args.es_url, args.es_insecure)


### PR DESCRIPTION
There is no way to make argparse arguments requirement depending on other params, so I have removed the requirement of --account-config and add a conditional to make it required if --es-index-only is not selected