### PR TITLE
add --skip-health-check flag to disable health tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ without uploading any information**
 | --log-file | File where to write logs. | -- |
 | --log-level | Level of logs to show. | INFO |
 | --dry-run | Perform a dry-run of the script without creating any cluster | False |
+| --skip-health-check | Do not run Health Checks after cluster is installed by osde2e | False |
 
 ## Account Configuration File
 


### PR DESCRIPTION
After cluster is installed by osde2e tool, a health check is done on the cluster.
This flag will disable that execution