### PR TITLE
add a parameter to gathering facts after cluster installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ without uploading any information**
 | --log-level | Level of logs to show. | INFO |
 | --dry-run | Perform a dry-run of the script without creating any cluster | False |
 | --skip-health-check | Do not run Health Checks after cluster is installed by osde2e | False |
+|--osde2e-must-gather | Enable gathering facts after cluster installation | False
+
 
 ## Account Configuration File
 


### PR DESCRIPTION
- gathering facts will only happens when **--osde2e-must-gather**
- console log of osde2e test command is redirected to <<cluster folder>>/installation.log

Disk Space saving:
- Complete installation: 59M
- Installation without gathering facts: 5.4M
- Installation without health-checks and gathering facts: 468K
- Installation without health-checks and gathering facts and logs compressed: 180K