### PR TITLE
Assign a unique cluster name to each cluster based on the parameter --cluster-name-seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The wrapper takes the following required variables:
 | Option | Description | Default |
 |--------|-------------|---------|
 | --account-config | The account configuration file to be used as the basis for the run.<br>**NOTE: See the Account Configuration File section for more details** | -- |
-| --cluster-name-seed | Seed for naming all clusters. No more than 6 chars or it will be truncated | -- |
+| --cluster-name-seed | Seed for naming all clusters. No more than 6 chars or it will be truncated | osde2e |
 
 ### Optional Elasticsearch variables
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The wrapper takes the following required variables:
 | Option | Description | Default |
 |--------|-------------|---------|
 | --account-config | The account configuration file to be used as the basis for the run.<br>**NOTE: See the Account Configuration File section for more details** | -- |
+| --cluster-name-seed | Seed for naming all clusters. No more than 6 chars or it will be truncated | -- |
 
 ### Optional Elasticsearch variables
 

--- a/osde2e-wrapper.py
+++ b/osde2e-wrapper.py
@@ -352,6 +352,7 @@ def main():
         default=False)
     parser.add_argument(
         '--cluster-name-seed',
+        default='osde2e',
         type=str,
         help='Seed used to generate cluster names. 6 chars max')
     parser.add_argument(
@@ -409,8 +410,8 @@ def main():
     )
     args = parser.parse_args()
 
-    if not args.es_index_only and (not args.account_config or not args.cluster_name_seed):
-        parser.error('the following arguments are required: --account-config AND --cluster-name-seed')
+    if not args.es_index_only and not args.account_config:
+        parser.error('the following arguments are required: --account-config')
 
     if args.es_url is not None:
         es = _connect_to_es(args.es_url, args.es_insecure)

--- a/osde2e-wrapper.py
+++ b/osde2e-wrapper.py
@@ -76,6 +76,7 @@ def _index_result(es,index,metadata,index_retry):
         my_doc['install_phase_pass_rate'] = key_exists('install-phase-pass-rate',metadata)
         my_doc['upgrade_phase_pass_rate'] = key_exists('upgrade-phase-pass-rate',metadata)
         if 'log-metrics' in metadata:
+            my_doc['log_metrics'] = {}
             my_doc['log_metrics']['access_token_500'] = key_exists('access-token-500',metadata['log-metrics'])
             my_doc['log_metrics']['cluster_mgmt_500'] = key_exists('cluster-mgmt-500',metadata['log-metrics'])
             my_doc['log_metrics']['cluster_pending'] = key_exists('cluster-pending',metadata['log-metrics'])
@@ -352,7 +353,7 @@ def main():
     parser.add_argument(
         '--cluster-name-seed',
         type=str,
-        help='Seed used to generate cluster names.')
+        help='Seed used to generate cluster names. 6 chars max')
     parser.add_argument(
         '--cluster-count',
         default=1,


### PR DESCRIPTION
- Added --cluster-name-seed parameter

Cluster name seed is limited to 6 chars because max long of cluster name is 15

seed (6) + "-" + rand(3) + "-" + cluster_index(4)

According to cluster_index, test is limited to 9999 cluster installation.

- Folders created for each cluster are now the cluster_name, instead of 1,2,3,...

- added log_metrics initialization on ES uploading function