### PR TITLE
Metadata document update with parser

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,3 +25,6 @@ jobs:
     - name: Tox
       run: |
         tox .
+    - name: Unit tests
+      run: |
+        python -m unittest test_osde2e-wrapper.py

--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ without uploading any information**
 | --log-level | Level of logs to show. | INFO |
 | --dry-run | Perform a dry-run of the script without creating any cluster | False |
 | --skip-health-check | Do not run Health Checks after cluster is installed by osde2e | False |
-|--osde2e-must-gather | Enable gathering facts after cluster installation | False
-
+| --osde2e-must-gather | Enable gathering facts after cluster installation | False |
+| --ignored-metadata | List of keys to ignore from the metadata file | ```before-suite-metrics route-latencies route-throughputs route-availabilities healthchecks healthcheckIteration status```
 
 ## Account Configuration File
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ without uploading any information**
 | --es-index | The index to write to. | osde2e-install-timings |
 | --es-index-retry | Number of retries to connect to ES | 5 |
 | --es-index-only | Upload all metadata.json files found under PATH to elasticsearch | -- |
+| --es-ignored-metadata | List of keys to ignore from the metadata file | ```before-suite-metrics route-latencies route-throughputs route-availabilities healthchecks healthcheckIteration status``` |
 
 ### Optional variables
 
@@ -80,7 +81,6 @@ without uploading any information**
 | --dry-run | Perform a dry-run of the script without creating any cluster | False |
 | --skip-health-check | Do not run Health Checks after cluster is installed by osde2e | False |
 | --osde2e-must-gather | Enable gathering facts after cluster installation | False |
-| --ignored-metadata | List of keys to ignore from the metadata file | ```before-suite-metrics route-latencies route-throughputs route-availabilities healthchecks healthcheckIteration status```
 
 ## Account Configuration File
 

--- a/osde2e-wrapper.py
+++ b/osde2e-wrapper.py
@@ -128,7 +128,7 @@ def _verify_cmnd(osde2e_cmnd,my_path):
         logging.info('Cloning osde2e git repository')
         try:
             git.Repo.clone_from("https://github.com/openshift/osde2e.git", osde2e_path, kill_after_timeout=300)
-        except git.exc.GitCommandError as err:
+        except git.GitCommandError as err:
             logging.error(err)
             exit(1)
 

--- a/osde2e-wrapper.py
+++ b/osde2e-wrapper.py
@@ -29,7 +29,7 @@ import string
 import random
 from ruamel.yaml import YAML
 
-_ignoredMetadata = ['before-suite-metrics','route-latencies','route-throughputs','route-availabilities','healthchecks','healthcheckIteration','status']
+_es_ignored_metadata = ['before-suite-metrics','route-latencies','route-throughputs','route-availabilities','healthchecks','healthcheckIteration','status']
 
 def _connect_to_es(es_url, insecure):
     if es_url.startswith('https://'):
@@ -345,6 +345,12 @@ def main():
         action='store_true',
         help='Do not install any new cluster, just upload to ES all metadata files found on PATH')
     parser.add_argument(
+        '--es-ignored-metadata',
+        dest='es_ignored_metadata',
+        default=_es_ignored_metadata,
+        nargs='+',
+        help='List of keys to ignore from the metadata file.')
+    parser.add_argument(
         '--uuid',
         help='UUID to provide to ES')
     parser.add_argument(
@@ -419,12 +425,6 @@ def main():
         dest='osde2e_must_gather',
         help='Add a must-gather operation at the end of the osde2e test process',
         action='store_true')
-    parser.add_argument(
-        '--ignored-metadata',
-        dest='ignoredMetadata',
-        default=_ignoredMetadata,
-        nargs='+',
-        help='List of keys to ignore from the metadata file.')
     args = parser.parse_args()
 
     if not args.es_index_only and not args.account_config:
@@ -467,7 +467,7 @@ def main():
                 except Exception as err:
                     logging.error(err)
                     logging.error('Failed to load metadata.json file located %s' % metadata_file)
-                index_result += _index_result(es,args.es_index,metadata,_ignoredMetadata,args.es_index_retry)
+                index_result += _index_result(es,args.es_index,metadata,args.es_ignored_metadata,args.es_index_retry)
         else:
             logging.error('PATH and elastic related parameters required when uploading data to elastic')
             exit(1)
@@ -613,7 +613,7 @@ def main():
                 logging.debug('Starting Cluster thread %d for cluster %s' % (loop_counter + 1,my_cluster_config['cluster']['name']))
                 try:
                     timestamp = time.strftime("%Y-%m-%dT%H:%M:%S")
-                    thread = threading.Thread(target=_build_cluster,args=(cmnd_path + "/osde2e", cmnd_path + "/osde2ectl", my_cluster_config,my_path,es,args.es_index,my_uuid,loop_counter,args.cluster_count,timestamp,args.dry_run,args.es_index_retry,args.skip_health_check,args.osde2e_must_gather,args.ignoredMetadata))
+                    thread = threading.Thread(target=_build_cluster,args=(cmnd_path + "/osde2e", cmnd_path + "/osde2ectl", my_cluster_config,my_path,es,args.es_index,my_uuid,loop_counter,args.cluster_count,timestamp,args.dry_run,args.es_index_retry,args.skip_health_check,args.osde2e_must_gather,args.es_ignored_metadata))
                 except Exception as err:
                     logging.error(err)
                 cluster_thread_list.append(thread)

--- a/osde2e-wrapper.py
+++ b/osde2e-wrapper.py
@@ -29,7 +29,7 @@ import string
 import random
 from ruamel.yaml import YAML
 
-_ignoredMetadata = []
+_ignoredMetadata = ['before-suite-metrics','route-latencies','route-throughputs','route-availabilities','healthchecks','healthcheckIteration','status']
 
 def _connect_to_es(es_url, insecure):
     if es_url.startswith('https://'):
@@ -419,6 +419,12 @@ def main():
         dest='osde2e_must_gather',
         help='Add a must-gather operation at the end of the osde2e test process',
         action='store_true')
+    parser.add_argument(
+        '--ignored-metadata',
+        dest='ignoredMetadata',
+        default=_ignoredMetadata,
+        nargs='+',
+        help='List of keys to ignore from the metadata file.')
     args = parser.parse_args()
 
     if not args.es_index_only and not args.account_config:
@@ -607,7 +613,7 @@ def main():
                 logging.debug('Starting Cluster thread %d for cluster %s' % (loop_counter + 1,my_cluster_config['cluster']['name']))
                 try:
                     timestamp = time.strftime("%Y-%m-%dT%H:%M:%S")
-                    thread = threading.Thread(target=_build_cluster,args=(cmnd_path + "/osde2e", cmnd_path + "/osde2ectl", my_cluster_config,my_path,es,args.es_index,my_uuid,loop_counter,args.cluster_count,timestamp,args.dry_run,args.es_index_retry,args.skip_health_check,args.osde2e_must_gather))
+                    thread = threading.Thread(target=_build_cluster,args=(cmnd_path + "/osde2e", cmnd_path + "/osde2ectl", my_cluster_config,my_path,es,args.es_index,my_uuid,loop_counter,args.cluster_count,timestamp,args.dry_run,args.es_index_retry,args.skip_health_check,args.osde2e_must_gather,args.ignoredMetadata))
                 except Exception as err:
                     logging.error(err)
                 cluster_thread_list.append(thread)

--- a/test_osde2e-wrapper.py
+++ b/test_osde2e-wrapper.py
@@ -12,9 +12,8 @@
 #   limitations under the License.
 
 import unittest
-import importlib  
+import importlib
 import json
-import time
 
 
 metadata = json.loads("""
@@ -22,33 +21,34 @@ metadata = json.loads("""
 "timestamp": "2021-02-05T16:16:11", "cluster-id": "1ikrg2ioq096pvkruhrs6o7p0btb7blp", "cluster-name": "osde2e-18hgn", "cluster-version": "openshift-v4.6.15", "environment": "prod", "region": "us-east-1", "time-to-ocm-reporting-installed": "1770.729182375", "time-to-cluster-ready": "1740.389981614", "time-to-upgraded-cluster": "0", "time-to-upgraded-cluster-ready": "0", "time-to-certificate-issued": "119.030519994", "install-phase-pass-rate": "-1", "upgrade-phase-pass-rate": "-1", "log-metrics": {"access-token-500": 0, "cluster-mgmt-500": 0, "cluster-pending": 0, "eof": 0, "host-dns-lookup": 0}, "before-suite-metrics": {"AMI ID Retieval Failure": 0, "AWS client creation failure": 0, "AWS credentials not valid": 0, "AWS error due to missing source clusterconfig": 0, "AWS image AMI failure": 0, "AWS region not enabled": 0, "BYOC account vaildation failure": 0, "Error in PollClusterHealth": 0, "Setting osa_use_marketplace_ami property manually": 0, "Test Panicked due to runtime error": 0, "cluster-health-check": 0, "cluster-install timeout": 0, "cluster-retrieval OCM error": 0, "cluster-setup": 0, "error creating cluster": 0, "failed to get access keys for user 'osdCcsAdmin'": 0, "missing quota for cluster creation": 0, "quota-check": 0, "running task Updating Alertmanager failed": 0, "timed out waiting for the condition during syncRequiredMachineConfigPools": 0}, "route-latencies": {}, "route-throughputs": {}, "route-availabilities": {}, "healthchecks": {}, "healthcheckIteration": 118, "status": "ready", "cluster_start_time": "2021-02-04T14:34:49", "cluster_end_time": "2021-02-04T15:38:13", "install_successful": true, "uuid": "98f26b1d-faaf-4894-ac22-0a5383849b78", "install_counter": 82}
 """)
 
-expected = {'timestamp': '2021-02-05T16:16:11', 
-        'cluster_start_time': '2021-02-04T14:34:49',
-        'cluster_end_time': '2021-02-04T15:38:13',
-        'install_successful': True,
-        'uuid': '98f26b1d-faaf-4894-ac22-0a5383849b78',
-        'install_counter': 82,
-        'cluster_id': '1ikrg2ioq096pvkruhrs6o7p0btb7blp',
-        'cluster_name': 'osde2e-18hgn',
-        'cluster_version': 'openshift-v4.6.15',
-        'environment': 'prod',
-        'region': 'us-east-1',
-        'details_url': '',
-        'time_to_ocm_reporting_installed': 1770,
-        'time_to_cluster_ready': 1740,
-        'time_to_upgraded_cluster': 0,
-        'time_to_upgraded_cluster_ready': 0,
-        'time_to_certificate_issued': 119,
-        'install_phase_pass_rate': '-1',
-        'upgrade_phase_pass_rate': '-1',
-        'log_metrics': {
-            'access_token_500': 0,
-            'cluster_mgmt_500': 0,
-            'cluster_pending': 0,
-            'eof': 0,
-            'host_dns_lookup': 0,
-        },
-    }
+expected = {'timestamp': '2021-02-05T16:16:11',
+            'cluster_start_time': '2021-02-04T14:34:49',
+            'cluster_end_time': '2021-02-04T15:38:13',
+            'install_successful': True,
+            'uuid': '98f26b1d-faaf-4894-ac22-0a5383849b78',
+            'install_counter': 82,
+            'cluster_id': '1ikrg2ioq096pvkruhrs6o7p0btb7blp',
+            'cluster_name': 'osde2e-18hgn',
+            'cluster_version': 'openshift-v4.6.15',
+            'environment': 'prod',
+            'region': 'us-east-1',
+            'details_url': '',
+            'time_to_ocm_reporting_installed': 1770,
+            'time_to_cluster_ready': 1740,
+            'time_to_upgraded_cluster': 0,
+            'time_to_upgraded_cluster_ready': 0,
+            'time_to_certificate_issued': 119,
+            'install_phase_pass_rate': '-1',
+            'upgrade_phase_pass_rate': '-1',
+            'log_metrics': {
+                'access_token_500': 0,
+                'cluster_mgmt_500': 0,
+                'cluster_pending': 0,
+                'eof': 0,
+                'host_dns_lookup': 0,
+                },
+            }
+
 
 class TestBuildDocument(unittest.TestCase):
 
@@ -57,6 +57,7 @@ class TestBuildDocument(unittest.TestCase):
         doc = wrapper.buildDoc(metadata)
         self.maxDiff = None
         self.assertDictEqual(doc,expected)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test_osde2e-wrapper.py
+++ b/test_osde2e-wrapper.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import unittest
+import importlib  
+import json
+import time
+
+
+metadata = json.loads("""
+{
+"timestamp": "2021-02-05T16:16:11", "cluster-id": "1ikrg2ioq096pvkruhrs6o7p0btb7blp", "cluster-name": "osde2e-18hgn", "cluster-version": "openshift-v4.6.15", "environment": "prod", "region": "us-east-1", "time-to-ocm-reporting-installed": "1770.729182375", "time-to-cluster-ready": "1740.389981614", "time-to-upgraded-cluster": "0", "time-to-upgraded-cluster-ready": "0", "time-to-certificate-issued": "119.030519994", "install-phase-pass-rate": "-1", "upgrade-phase-pass-rate": "-1", "log-metrics": {"access-token-500": 0, "cluster-mgmt-500": 0, "cluster-pending": 0, "eof": 0, "host-dns-lookup": 0}, "before-suite-metrics": {"AMI ID Retieval Failure": 0, "AWS client creation failure": 0, "AWS credentials not valid": 0, "AWS error due to missing source clusterconfig": 0, "AWS image AMI failure": 0, "AWS region not enabled": 0, "BYOC account vaildation failure": 0, "Error in PollClusterHealth": 0, "Setting osa_use_marketplace_ami property manually": 0, "Test Panicked due to runtime error": 0, "cluster-health-check": 0, "cluster-install timeout": 0, "cluster-retrieval OCM error": 0, "cluster-setup": 0, "error creating cluster": 0, "failed to get access keys for user 'osdCcsAdmin'": 0, "missing quota for cluster creation": 0, "quota-check": 0, "running task Updating Alertmanager failed": 0, "timed out waiting for the condition during syncRequiredMachineConfigPools": 0}, "route-latencies": {}, "route-throughputs": {}, "route-availabilities": {}, "healthchecks": {}, "healthcheckIteration": 118, "status": "ready", "cluster_start_time": "2021-02-04T14:34:49", "cluster_end_time": "2021-02-04T15:38:13", "install_successful": true, "uuid": "98f26b1d-faaf-4894-ac22-0a5383849b78", "install_counter": 82}
+""")
+
+expected = {'timestamp': '2021-02-05T16:16:11', 
+        'cluster_start_time': '2021-02-04T14:34:49',
+        'cluster_end_time': '2021-02-04T15:38:13',
+        'install_successful': True,
+        'uuid': '98f26b1d-faaf-4894-ac22-0a5383849b78',
+        'install_counter': 82,
+        'cluster_id': '1ikrg2ioq096pvkruhrs6o7p0btb7blp',
+        'cluster_name': 'osde2e-18hgn',
+        'cluster_version': 'openshift-v4.6.15',
+        'environment': 'prod',
+        'region': 'us-east-1',
+        'details_url': '',
+        'time_to_ocm_reporting_installed': 1770,
+        'time_to_cluster_ready': 1740,
+        'time_to_upgraded_cluster': 0,
+        'time_to_upgraded_cluster_ready': 0,
+        'time_to_certificate_issued': 119,
+        'install_phase_pass_rate': '-1',
+        'upgrade_phase_pass_rate': '-1',
+        'log_metrics': {
+            'access_token_500': 0,
+            'cluster_mgmt_500': 0,
+            'cluster_pending': 0,
+            'eof': 0,
+            'host_dns_lookup': 0,
+        },
+    }
+
+class TestBuildDocument(unittest.TestCase):
+
+    def test_buildDoc(self):
+        wrapper = importlib.import_module("osde2e-wrapper")
+        doc = wrapper.buildDoc(metadata)
+        self.maxDiff = None
+        self.assertDictEqual(doc,expected)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test_osde2e-wrapper.py
+++ b/test_osde2e-wrapper.py
@@ -32,14 +32,19 @@ expected = {'timestamp': '2021-02-05T16:16:11',
             'cluster_version': 'openshift-v4.6.15',
             'environment': 'prod',
             'region': 'us-east-1',
-            'details_url': '',
             'time_to_ocm_reporting_installed': 1770,
             'time_to_cluster_ready': 1740,
             'time_to_upgraded_cluster': 0,
             'time_to_upgraded_cluster_ready': 0,
             'time_to_certificate_issued': 119,
-            'install_phase_pass_rate': '-1',
-            'upgrade_phase_pass_rate': '-1',
+            'install_phase_pass_rate': -1,
+            'upgrade_phase_pass_rate': -1,
+            'route_availabilities': {},
+            'route_latencies': {},
+            'route_throughputs': {},
+            'healthchecks': {},
+            'healthcheckiteration': 118,
+            'status': 'ready',
             'log_metrics': {
                 'access_token_500': 0,
                 'cluster_mgmt_500': 0,
@@ -47,16 +52,149 @@ expected = {'timestamp': '2021-02-05T16:16:11',
                 'eof': 0,
                 'host_dns_lookup': 0,
                 },
+            'before_suite_metrics': {
+                'ami_id_retieval_failure': 0,
+                'aws_client_creation_failure': 0,
+                'aws_credentials_not_valid': 0,
+                'aws_error_due_to_missing_source_clusterconfig': 0,
+                'aws_image_ami_failure': 0,
+                'aws_region_not_enabled': 0,
+                'byoc_account_vaildation_failure': 0,
+                'cluster_health_check': 0,
+                'cluster_install_timeout': 0,
+                'cluster_retrieval_ocm_error': 0,
+                'cluster_setup': 0,
+                'error_creating_cluster': 0,
+                'error_in_pollclusterhealth': 0,
+                "failed_to_get_access_keys_for_user_'osdccsadmin'": 0,
+                'missing_quota_for_cluster_creation': 0,
+                'quota_check': 0,
+                'running_task_updating_alertmanager_failed': 0,
+                'setting_osa_use_marketplace_ami_property_manually': 0,
+                'test_panicked_due_to_runtime_error': 0,
+                'timed_out_waiting_for_the_condition_during_syncrequiredmachineconfigpools': 0
+                },
             }
+
+expected2 = {'timestamp': '2021-02-05T16:16:11',
+             'cluster_start_time': '2021-02-04T14:34:49',
+             'cluster_end_time': '2021-02-04T15:38:13',
+             'install_successful': True,
+             'uuid': '98f26b1d-faaf-4894-ac22-0a5383849b78',
+             'install_counter': 82,
+             'cluster_id': '1ikrg2ioq096pvkruhrs6o7p0btb7blp',
+             'cluster_name': 'osde2e-18hgn',
+             'cluster_version': 'openshift-v4.6.15',
+             'environment': 'prod',
+             'region': 'us-east-1',
+             'time_to_ocm_reporting_installed': 1770,
+             'time_to_cluster_ready': 1740,
+             'time_to_upgraded_cluster': 0,
+             'time_to_upgraded_cluster_ready': 0,
+             'time_to_certificate_issued': 119,
+             'install_phase_pass_rate': -1,
+             'upgrade_phase_pass_rate': -1,
+             'route_availabilities': {},
+             'route_latencies': {},
+             'route_throughputs': {},
+             'healthchecks': {},
+             'healthcheckiteration': 118,
+             'status': 'ready',
+             'log_metrics': {
+                 'access_token_500': 0,
+                 'cluster_mgmt_500': 0,
+                 'cluster_pending': 0,
+                 'host_dns_lookup': 0,
+                 },
+             }
 
 
 class TestBuildDocument(unittest.TestCase):
 
     def test_buildDoc(self):
         wrapper = importlib.import_module("osde2e-wrapper")
-        doc = wrapper.buildDoc(metadata)
+        doc = wrapper._buildDoc(metadata, [])
         self.maxDiff = None
         self.assertDictEqual(doc,expected)
+        # Test ignored<etadata feature
+        doc = wrapper._buildDoc(metadata, ['before-suite-metrics','eof'])
+        self.maxDiff = None
+        self.assertDictEqual(doc,expected2)
+
+class Case(object):
+    def __init__(self, caseName, value, expectedType, expectError):
+        self.caseName = caseName
+        self.value = value
+        self.expectedType = expectedType
+        self.expectError = expectError
+
+class TestParseValues(unittest.TestCase):
+
+    def test_getValue(self):
+        wrapper = importlib.import_module("osde2e-wrapper")
+        cases = []
+        cases.append(Case("01-boolean", True, bool, False))
+        cases.append(Case("02-boolean", False, bool, False))
+        cases.append(Case("03-notBoolean", 0, bool, True))
+        cases.append(Case("04-notBoolean", 1, bool, True))
+        cases.append(Case("05-notBoolean", "1", bool, True))
+        cases.append(Case("06-notBoolean", "asdf", bool, True))
+        cases.append(Case("07-notBoolean", 12.9876543, bool, True))
+        cases.append(Case("08-notBoolean", "12.9876543", bool, True))
+        cases.append(Case("09-notBoolean", {}, bool, True))
+        cases.append(Case("10-notBoolean", [], bool, True))
+        cases.append(Case("01-notInt", True, int, True))
+        cases.append(Case("02-notInt", False, int, True))
+        cases.append(Case("03-int", 0, int, False))
+        cases.append(Case("04-int", 1, int, False))
+        cases.append(Case("05-int", "1", int, False))
+        cases.append(Case("06-notInt", "asdf", int, True))
+        # This might be confussing but we are not using the decimal
+        # part of the number so it gets truncated into an int.
+        cases.append(Case("07-notInt", 12.9876543, int, False))
+        cases.append(Case("08-notInt", "12.9876543", int, False))
+        cases.append(Case("09-notInt", {}, int, True))
+        cases.append(Case("10-notInt", [], int, True))
+        cases.append(Case("01-notFloat", True, float, True))
+        cases.append(Case("02-notFloat", False, float, True))
+        cases.append(Case("03-notFloat", 0, float, True))
+        cases.append(Case("04-notFloat", 1, float, True))
+        cases.append(Case("05-notFloat", "1", float, True))
+        cases.append(Case("06-notFloat", "asdf", float, True))
+        # This might be confussing but we are not using the decimal
+        # part of the number so it gets truncated into an int.
+        cases.append(Case("07-float", 12.9876543, int, False))
+        cases.append(Case("08-float", "12.9876543", int, False))
+        cases.append(Case("09-notFloat", {}, float, True))
+        cases.append(Case("10-notFloat", [], float, True))
+        cases.append(Case("01-notString", True, str, True))
+        cases.append(Case("02-notString", False, str, True))
+        cases.append(Case("03-notString", 0, str, True))
+        cases.append(Case("04-notString", 1, str, True))
+        cases.append(Case("05-notString", "1", str, True))
+        cases.append(Case("06-string", "asdf", str, False))
+        cases.append(Case("07-notString", 12.9876543, str, True))
+        cases.append(Case("08-notString", "12.9876543", str, True))
+        cases.append(Case("09-notString", {}, str, True))
+        cases.append(Case("10-notString", [], str, True))
+        cases.append(Case("01-notDict", True, dict, True))
+        cases.append(Case("02-notDict", False, dict, True))
+        cases.append(Case("03-notDict", 0, dict, True))
+        cases.append(Case("04-notDict", 1, dict, True))
+        cases.append(Case("05-notDict", "1", dict, True))
+        cases.append(Case("06-notDict", "asdf", dict, True))
+        cases.append(Case("07-notDict", 12.9876543, dict, True))
+        cases.append(Case("08-notDict", "12.9876543", dict, True))
+        cases.append(Case("09-dict", {}, dict, False))
+        cases.append(Case("10-notDict", [], dict, True))
+        cases.append(Case("11-dict", {'1': {'2': {'3': {'4': 6}}}}, dict, False))
+
+        for case in cases:
+            v = wrapper._getValue(case.value,[])
+            if not case.expectError:
+                self.assertEqual(case.expectedType, type(v), "error in case {}: input {}".format(case.caseName, case.value))
+            else:
+                self.assertNotEqual(case.expectedType, type(v), "error in case {}: input {}".format(case.caseName, case.value))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Adds ability to parse the metadata json file.

This will generate the ES document to be stored.
Adds the ability to ignore metadata by key name.
Adds unit tests for new functions.

supersedes #58 
fixes #53 

Signed-off-by: Vicente Zepeda Mas <vzepedam@redhat.com>

