### PR TITLE
Adds aparent parameter parsers to avoid duplicated code

### DIFF
--- a/libs/parentParsers.py
+++ b/libs/parentParsers.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import argparse
+from . import common
+
+
+esParser = argparse.ArgumentParser(add_help=False)
+esParser.add_argument(
+    '--es-url',
+    help='Provide ES connection URL')
+esParser.add_argument(
+    '--es-insecure',
+    dest='es_insecure',
+    action='store_true',
+    help='if ES is setup with ssl, but can disable tls cert verification')
+esParser.add_argument(
+    '--es-index',
+    help='The index to write to',
+    default='osde2e-install-timings')
+esParser.add_argument(
+    '--es-index-retry',
+    help='Number of retries (default: 5) on ES uploading. The time between retries increases exponentially',
+    default=5,
+    type=int)
+esParser.add_argument(
+    '--es-index-only',
+    dest='es_index_only',
+    action='store_true',
+    help='Do not install any new cluster, just upload to ES all metadata files found on PATH')
+esParser.add_argument(
+    '--es-ignored-metadata',
+    dest='es_ignored_metadata',
+    default=common._es_ignored_metadata,
+    help='List of coma separated keys to ignore from the metadata file.')
+esParser.add_argument(
+    '--uuid',
+    help='UUID to provide to ES')
+
+runnerParser = argparse.ArgumentParser(add_help=False)
+runnerParser.add_argument(
+    '--path',
+    help='Path to save temporary data')
+runnerParser.add_argument(
+    '--cleanup',
+    help='Should we delete the temporary directory',
+    default=False)
+runnerParser.add_argument(
+    '--delay-between-batch',
+    type=int,
+    help='If set it will wait x seconds between each batch request')
+runnerParser.add_argument(
+    '--batch-size',
+    default=0,
+    type=int,
+    help='number of clusters in a batch')
+runnerParser.add_argument(
+    '--watcher-delay',
+    default=60,
+    type=int,
+    help='Delay between each status check')
+
+clusterParser = argparse.ArgumentParser(add_help=False)
+clusterParser.add_argument(
+    '--cluster-name-seed',
+    type=str,
+    default='osde2e',
+    help='Seed used to generate cluster names. 6 chars max')
+clusterParser.add_argument(
+    '--cluster-count',
+    default=1,
+    type=int,
+    help='Total number of clusters to create')
+clusterParser.add_argument(
+    '--expire',
+    type=int,
+    help='Minutes until cluster expires and it is deleted by OSD')
+clusterParser.add_argument(
+    '--cleanup-clusters',
+    default=True,
+    help='Cleanup any non-error state clusters upon test completion')
+
+
+logParser = argparse.ArgumentParser(add_help=False)
+logParser.add_argument(
+    '--log-file',
+    help='File where to write logs')
+logParser.add_argument(
+    '--log-level',
+    default='INFO',
+    help='Log level to show')

--- a/osde2e/osde2e-wrapper.py
+++ b/osde2e/osde2e-wrapper.py
@@ -26,6 +26,7 @@ import copy
 import string
 import random
 from libs import common
+from libs import parentParsers
 from ruamel.yaml import YAML
 
 
@@ -232,78 +233,17 @@ def _cleanup_clusters(osde2ectl_cmd,my_path,account_config):
     logging.info(error)
 
 def main():
-    parser = argparse.ArgumentParser(description="osde2e wrapper script")
+    parser = argparse.ArgumentParser(description="osde2e wrapper script",
+                                     parents=[parentParsers.esParser,
+                                              parentParsers.runnerParser,
+                                              parentParsers.clusterParser,
+                                              parentParsers.logParser])
     parser.add_argument(
         '--account-config',
         help='Yaml account config')
     parser.add_argument(
-        '--es-url',
-        help='Provide ES connection URL')
-    parser.add_argument(
-        '--es-insecure',
-        dest='es_insecure',
-        action='store_true',
-        help='if ES is setup with ssl, but can disable tls cert verification')
-    parser.add_argument(
-        '--es-index',
-        help='The index to write to',
-        default='osde2e-install-timings')
-    parser.add_argument(
-        '--es-index-retry',
-        help='Number of retries (default: 5) on ES uploading. The time between retries increases exponentially',
-        default=5,
-        type=int)
-    parser.add_argument(
-        '--es-index-only',
-        dest='es_index_only',
-        action='store_true',
-        help='Do not install any new cluster, just upload to ES all metadata files found on PATH')
-    parser.add_argument(
-        '--es-ignored-metadata',
-        dest='es_ignored_metadata',
-        default=common._es_ignored_metadata,
-        help='List of coma separated keys to ignore from the metadata file.')
-    parser.add_argument(
-        '--uuid',
-        help='UUID to provide to ES')
-    parser.add_argument(
         '-c', '--command',
         help='Full path to the osde2e and osde2ectl command directory. If not provided we will download and compile the latest')
-    parser.add_argument(
-        '--path',
-        help='Path to save temporary data')
-    parser.add_argument(
-        '--cleanup',
-        help='Should we delete the temporary directory',
-        default=False)
-    parser.add_argument(
-        '--cluster-name-seed',
-        type=str,
-        default='osde2e',
-        help='Seed used to generate cluster names. 6 chars max')
-    parser.add_argument(
-        '--cluster-count',
-        default=1,
-        type=int,
-        help='Total number of clusters to create')
-    parser.add_argument(
-        '--batch-size',
-        default=0,
-        type=int,
-        help='number of clusters in a batch')
-    parser.add_argument(
-        '--watcher-delay',
-        default=60,
-        type=int,
-        help='Delay between each status check')
-    parser.add_argument(
-        '--expire',
-        type=int,
-        help='Minutes until cluster expires and it is deleted by OSD')
-    parser.add_argument(
-        '--cleanup-clusters',
-        default=True,
-        help='Cleanup any non-error state clusters upon test completion')
     parser.add_argument(
         '--user-override',
         type=str,
@@ -312,17 +252,6 @@ def main():
         '--aws-account-file',
         type=str,
         help='AWS account file to use')
-    parser.add_argument(
-        '--delay-between-batch',
-        type=int,
-        help='If set it will wait x seconds between each batch request')
-    parser.add_argument(
-        '--log-file',
-        help='File where to write logs')
-    parser.add_argument(
-        '--log-level',
-        default='INFO',
-        help='Log level to show')
     parser.add_argument(
         '--dry-run',
         dest='dry_run',

--- a/rosa/rosa-wrapper.py
+++ b/rosa/rosa-wrapper.py
@@ -26,6 +26,7 @@ import threading
 import random
 import string
 from libs import common
+from libs import parentParsers
 
 # If rosa command path is provided verify we can run the help function
 # If it is not provided, dowload binary from the latest tag
@@ -231,85 +232,14 @@ def _cleanup_clusters(rosa_cmnd,cluster_name_seed):
     logging.info(error)
 
 def main():
-    parser = argparse.ArgumentParser(description="osde2e wrapper script")
-    parser.add_argument(
-        '--es-url',
-        help='Provide ES connection URL')
-    parser.add_argument(
-        '--es-insecure',
-        dest='es_insecure',
-        action='store_true',
-        help='if ES is setup with ssl, but can disable tls cert verification')
-    parser.add_argument(
-        '--es-index',
-        help='The index to write to',
-        default='osde2e-install-timings')
-    parser.add_argument(
-        '--es-index-retry',
-        help='Number of retries (default: 5) on ES uploading. The time between retries increases exponentially',
-        default=5,
-        type=int)
-    parser.add_argument(
-        '--es-index-only',
-        dest='es_index_only',
-        action='store_true',
-        help='Do not install any new cluster, just upload to ES all metadata files found on PATH')
-    parser.add_argument(
-        '--es-ignored-metadata',
-        dest='es_ignored_metadata',
-        default=common._es_ignored_metadata,
-        help='List of coma separated keys to ignore from the metadata file.')
-    parser.add_argument(
-        '--uuid',
-        help='UUID to provide to ES')
+    parser = argparse.ArgumentParser(description="osde2e wrapper script",
+                                     parents=[parentParsers.esParser,
+                                              parentParsers.runnerParser,
+                                              parentParsers.clusterParser,
+                                              parentParsers.logParser])
     parser.add_argument(
         '--rosa-cli',
         help='Full path to the rosa cli binary. If not provided we will download latest')
-    parser.add_argument(
-        '--path',
-        help='Path to save temporary data')
-    parser.add_argument(
-        '--cluster-name-seed',
-        type=str,
-        help='Seed used to generate cluster names.')
-    parser.add_argument(
-        '--cleanup',
-        help='Should we delete the temporary directory',
-        default=False)
-    parser.add_argument(
-        '--cluster-count',
-        default=1,
-        type=int,
-        help='Total number of clusters to create')
-    parser.add_argument(
-        '--batch-size',
-        default=0,
-        type=int,
-        help='number of clusters in a batch')
-    parser.add_argument(
-        '--watcher-delay',
-        default=60,
-        type=int,
-        help='Delay between each status check')
-    parser.add_argument(
-        '--expire',
-        type=int,
-        help='Minutes until cluster expires and it is deleted by OSD')
-    parser.add_argument(
-        '--cleanup-clusters',
-        default=True,
-        help='Cleanup any non-error state clusters upon test completion')
-    parser.add_argument(
-        '--delay-between-batch',
-        type=int,
-        help='If set it will wait x seconds between each batch request')
-    parser.add_argument(
-        '--log-file',
-        help='File where to write logs')
-    parser.add_argument(
-        '--log-level',
-        default='INFO',
-        help='Log level to show')
     parser.add_argument(
         '--rosa-init',
         dest='rosa_init',

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,8 @@ deps = -r{toxinidir}/test-requirements.txt
 basepython = python
 commands =
 	flake8 {posargs}
+	python -m py_compile libs/common.py
+	python -m py_compile libs/parentParsers.py
 	python -m py_compile osde2e/osde2e-wrapper.py
 	python -m py_compile rosa/rosa-wrapper.py
 	python -m py_compile tests/test_es_metadata.py


### PR DESCRIPTION
It creates parsers for:
- elasticsearch
- cluster config
- runner config
- logging

Signed-off-by: Vicente Zepeda Mas <vzepedam@redhat.com>