### PR TITLE
Fixes error referencing missing cluster_id key

### DIFF
--- a/libs/common.py
+++ b/libs/common.py
@@ -30,6 +30,12 @@ def _index_result(es,index,metadata,es_ignored_metadata,index_retry):
     logging.debug('Document to be uploaded to ES:')
     logging.debug(my_doc)
 
+    _id = ""
+    if 'cluster_id' in dict(my_doc).keys():
+        _id = my_doc['cluster_id']
+    else:
+        _id = my_doc['cluster_name']
+
     for attempt in range(index_retry + 1):
         try:
             time.sleep(5 * attempt)
@@ -39,10 +45,10 @@ def _index_result(es,index,metadata,es_ignored_metadata,index_retry):
             logging.error(e)
             logging.error('Failed to upload to ES, waiting %d seconds for next upload retry' % (5 * (attempt + 1)))
         else:
-            logging.debug('ES upload successful for cluster id %s' % my_doc['cluster_id'])
+            logging.debug('ES upload successful for cluster id %s' % _id)
             return 0
     else:
-        logging.error('Reached the maximun number of retries: %d, ES upload failed for %s' % (index_retry, my_doc['cluster_id']))
+        logging.error('Reached the maximun number of retries: %d, ES upload failed for %s' % (index_retry, _id))
         return 1
 
 def _buildDoc(metadata, es_ignored_metadata):

--- a/osde2e/osde2e-wrapper.py
+++ b/osde2e/osde2e-wrapper.py
@@ -133,6 +133,7 @@ def _build_cluster(osde2e_cmnd,osde2ectl_cmd,account_config,my_path,es,index,my_
             logging.error('Check installation.log and test_output.log files on %s for errors' % (cluster_path + "/"))
             success = False
         logging.info('Attempting to load metadata json')
+        metadata = {}
         try:
             metadata = json.load(open(cluster_path + "/metadata.json"))
         except Exception as err:


### PR DESCRIPTION
When trying to access `cluster_id` key when the creation of the cluster failed.

Adds validation to check for the key or instead use the cluster_name.

Fixes #72 

Signed-off-by: Vicente Zepeda Mas <vzepedam@redhat.com>