### PR TITLE
my_cluster_confg[cluster] was never declared before using a sub-key

### DIFF
--- a/osde2e/osde2e-wrapper.py
+++ b/osde2e/osde2e-wrapper.py
@@ -454,6 +454,8 @@ def main():
                 create_cluster = True
 
             if create_cluster:
+                if "cluster" not in my_cluster_config.keys():
+                    my_cluster_config['cluster'] = {}
                 my_cluster_config['cluster']['name'] = cluster_name_seed + "-" + str(loop_counter).zfill(4)
                 logging.debug('Starting Cluster thread %d for cluster %s' % (loop_counter + 1,my_cluster_config['cluster']['name']))
                 try:


### PR DESCRIPTION
# Description
We are trying to use a subkey of my_cluster_config['cluster'] before it has been created. This results in the thread failing to be created and the test failing.
Fixes # (issue)
