### PR TITLE
Move string based arguments to boolean to better integration on jenkins

### DIFF
--- a/libs/parentParsers.py
+++ b/libs/parentParsers.py
@@ -54,7 +54,8 @@ runnerParser.add_argument(
 runnerParser.add_argument(
     '--cleanup',
     help='Should we delete the temporary directory',
-    default=False)
+    dest='cleanup',
+    action='store_true')
 runnerParser.add_argument(
     '--delay-between-batch',
     type=int,
@@ -87,7 +88,8 @@ clusterParser.add_argument(
     help='Minutes until cluster expires and it is deleted by OSD')
 clusterParser.add_argument(
     '--cleanup-clusters',
-    default=True,
+    dest='cleanup_clusters',
+    action='store_true',
     help='Cleanup any non-error state clusters upon test completion')
 clusterParser.add_argument(
     '--only-delete-clusters',

--- a/osde2e/README.md
+++ b/osde2e/README.md
@@ -74,7 +74,7 @@ without uploading any information**
 | --delay-between-batch | If set, we will wait X seconds between each batch request | -- |
 | --watcher-delay | Delay between each status check in seconds. | 60 |
 | --expire | Minutes until cluster expires and it is deleted by OSD. It sets CLUSTER_EXPIRY_IN_MINUTES var for osde2e | -- |
-| --cleanup-clusters | Cleanup any non-error state clusters upon test completion. | True |
+| --cleanup-clusters | Cleanup any non-error state clusters upon test completion. | False |
 | --user-override | User to set as the owner. <br>**NOTE: this takes precidence over what is provided in the account-config file** | -- |
 | --aws-account-file | AWS account file that provides account,accessKey,secretKey. This file will be looped over as needed to achieve all clusters requested. Example format: <br> ```0009808111,AAAA53YREVPCS111,00019ILbzo+yWU9C5FG5YrnoZC5eBg2111```<br>```0007006111,AAAAUZRL736SW6111,000P/b94AL+LSCzJBWbZCYRuYArF9Zr111```<br>Having AWS_PROFILE variable set will choose which profile to use. | -- |
 | --log-file | File where to write logs. | -- |

--- a/osde2e/osde2e-wrapper.py
+++ b/osde2e/osde2e-wrapper.py
@@ -520,16 +520,16 @@ def main():
         watcher.join()
 
     if args.cleanup_clusters and not args.dry_run:
-        cleanup = _cleanup_clusters(cmnd_path + "/osde2ectl",cluster_name_seed,my_path,account_config)
-        logging.warning('Cleanup process failed') if cleanup != 0 else None
+        cleanup_result = _cleanup_clusters(cmnd_path + "/osde2ectl",cluster_name_seed,my_path,account_config)
+        logging.warning('Cleanup process failed') if cleanup_result != 0 else None
 
-    if args.cleanup is True:
+    if args.cleanup:
         shutil.rmtree(my_path)
 
 # Last, output test result
     if not args.dry_run:
         logging.info('************************************************************************')
-        logging.info('********* Resume for test %s *********' % (my_uuid))
+        logging.info('********* Summary for test %s *********' % (my_uuid))
         logging.info('************************************************************************')
         logging.info('Requested Clusters for test %s: %d' % (my_uuid,args.cluster_count))
         logging.info('Created   Clusters for test %s: %d' % (my_uuid,account_config['clusters_created']))

--- a/rosa/README.md
+++ b/rosa/README.md
@@ -69,7 +69,7 @@ without uploading any information**
 | --delay-between-batch | If set, we will wait X seconds between each batch request | -- |
 | --watcher-delay | Delay between each status check in seconds. | 60 |
 | --expire | Minutes until cluster expires and it is deleted by OSD. It sets CLUSTER_EXPIRY_IN_MINUTES var for osde2e | -- |
-| --cleanup-clusters | Cleanup any non-error state clusters upon test completion. | True |
+| --cleanup-clusters | Cleanup any non-error state clusters upon test completion. | False |
 | --log-file | File where to write logs. | -- |
 | --log-level | Level of logs to show. | INFO |
 | --only-delete-clusters | Delete clusters found on folder specified by **--path**.<br>**NOTE: It will fail if no cluster_name_seed file is found on folder | False |

--- a/rosa/rosa-wrapper.py
+++ b/rosa/rosa-wrapper.py
@@ -476,15 +476,15 @@ def main():
     watcher.join()
 
     if args.cleanup_clusters:
-        cleanup = _cleanup_clusters(rosa_cmnd,cluster_name_seed)
-        logging.warning('Cleanup process failed') if cleanup != 0 else None
+        cleanup_result = _cleanup_clusters(rosa_cmnd,cluster_name_seed)
+        logging.warning('Cleanup process failed') if cleanup_result != 0 else None
 
-    if args.cleanup is True:
+    if args.cleanup:
         shutil.rmtree(my_path)
 
 # Last, output test result
     logging.info('************************************************************************')
-    logging.info('********* Resume for test %s *********' % (my_uuid))
+    logging.info('********* Summary for test %s *********' % (my_uuid))
     logging.info('************************************************************************')
     logging.info('Requested Clusters for test %s: %d' % (my_uuid,args.cluster_count))
     logging.info('Created   Clusters for test %s: %d' % (my_uuid,clusters_resume['clusters_created']))


### PR DESCRIPTION
- **--cleanup-clusters** has been moved to a bolean parameter.  If not defined, clusters will be preserved.
- 
This is because having a **--cleanup-clusters True** working by default and needing to explicity define **--cleanup-clusters False** is harder to transport to every job or execution. Boolean parameter is easier to integrate.

- **--cleanup  [True|False]** has been also moved to boolean parameter, so now it is only required to use **--cleanup** when we want to delete working folder and all its content, and do nothing if we want to preserve it (default)
