### PR TITLE
Add wildcard parameter on both wrappers and version on rosa

### DIFF
--- a/libs/parentParsers.py
+++ b/libs/parentParsers.py
@@ -96,6 +96,11 @@ clusterParser.add_argument(
     dest='only_delete_clusters',
     action='store_true',
     help="Just delete clusters found on folder specified by '--path' and exit")
+clusterParser.add_argument(
+    '--wildcard-options',
+    type=str,
+    help="Between quotes, any other parameter to be transfered to the binary without any validation")
+
 
 machinepoolParser = argparse.ArgumentParser(add_help=False)
 machinepoolParser.add_argument(

--- a/osde2e/README.md
+++ b/osde2e/README.md
@@ -83,6 +83,7 @@ without uploading any information**
 | --skip-health-check | Do not run Health Checks after cluster is installed by osde2e | False |
 | --osde2e-must-gather | Enable gathering facts after cluster installation | False |
 | --only-delete-clusters | Delete clusters found on folder specified by **--path**.<br>**NOTE: It will fail if no cluster_name_seed file is found on folder | False |
+| --wildcard-options | [Any other option to be passed to the osde2e binary](#wildcard-variable) | -- |
 
 ### Optional Machinepool variables
 
@@ -97,6 +98,18 @@ A new machinepool can be created on each cluster after installation if `--machin
 | --machinepool-replicas | Number of hosts to create on the machinepool. | 2 |
 | --machinepool-wait | Wait until number of ready nodes equals number of required replicas | False |
 | --machinepool-wait-cycles | Number of 5 seconds wait cycles until halts the waiting | 60 |
+
+### Wildcard variable
+
+The osde2e tool is accepting more and more parameters with every new version, using `--wildcard-options` will transfer the followed string directly to the `osde2e test` execution.
+
+For example:
+
+`osde2e-wrapper.py --cluster-name-seed mrnd --cluster-count 1 --wildcard-options "--secret-locations /tmp"`
+
+Will execute:
+
+`osde2e test --secret-locations /tmp`
 
 ## Account Configuration File
 

--- a/osde2e/osde2e-wrapper.py
+++ b/osde2e/osde2e-wrapper.py
@@ -208,6 +208,9 @@ def _build_cluster(osde2e_cmnd,osde2ectl_cmd,account_config,my_path,es,index,my_
     cluster_cmd = [osde2e_cmnd, "test","--custom-config", "cluster_account.yaml"]
     cluster_cmd.append('--skip-health-check') if skip_health_check else None
     cluster_cmd.append('--must-gather=false') if not must_gather else None
+    if args.wildcard_options:
+        for param in args.wildcard_options.split():
+            cluster_cmd.append(param)
     if not dry_run:
         logging.debug(cluster_cmd)
         installation_log = open(cluster_path + "/" + 'installation.log', 'w')

--- a/rosa/README.md
+++ b/rosa/README.md
@@ -63,6 +63,7 @@ without uploading any information**
 | --rosa-multi-az | Install ROSA clusters with multi-az support, deploying on multiple datacenters | False |
 | --rosa-addons | Comma separated list of addons to be added after cluster installation | -- |
 | --rosa-flavour | AWS Flavour to be use on the infra nodes | -- |
+| --rosa-version | OCP version used to install the cluster | -- |
 | --aws-profile | AWS profile to use if there is more than one on AWS cli configuration file | -- |
 | --cluster-count | Total number of clusters to create. | 1 |
 | --batch-size | Number of clusters to create in a batch. If not set it will try and create them all at once. <br>**NOTE**: If not used in conjunction with --delay-between-batch the cluster creation will block at the set batch size until one completes then continue. I.e. if 3 clusters are requested with a batch size of 2. The first two will be requested and then it will block until one of those completes to request the third. | -- |
@@ -73,6 +74,7 @@ without uploading any information**
 | --log-file | File where to write logs. | -- |
 | --log-level | Level of logs to show. | INFO |
 | --only-delete-clusters | Delete clusters found on folder specified by **--path**.<br>**NOTE: It will fail if no cluster_name_seed file is found on folder | False |
+| --wildcard-options | [Any other option to be passed to the rosa binary](#wildcard-variable) | -- |
 
 ### Optional Machinepool variables
 
@@ -87,6 +89,18 @@ A new machinepool can be created on each cluster after installation if `--machin
 | --machinepool-replicas | Number of hosts to create on the machinepool. | 2 |
 | --machinepool-wait | Wait until number of ready nodes equals number of required replicas | False |
 | --machinepool-wait-cycles | Number of 5 seconds wait cycles until halts the waiting | 60 |
+
+### Wildcard variable
+
+The rosa tool is accepting more and more parameters with every new version, using `--wildcard-options` will transfer the followed string directly to the `rosa create cluster` execution.
+
+For example:
+
+`rosa-wrapper.py --cluster-name-seed mrnd --cluster-count 1 --wildcard-options "--region us-west-2"`
+
+Will execute:
+
+`rosa create cluster --region us-west-2`
 
 ## AWS Configuration File
 

--- a/rosa/rosa-wrapper.py
+++ b/rosa/rosa-wrapper.py
@@ -189,6 +189,12 @@ def _build_cluster(rosa_cmnd,cluster_name_seed,expiration,rosa_azs,my_path,es,in
         cluster_cmd.append('--multi-az')
     if rosa_flavour:
         cluster_cmd.append('--flavour=' + rosa_flavour)
+    if args.rosa_version:
+        cluster_cmd.append('--version')
+        cluster_cmd.append(args.rosa_version)
+    if args.wildcard_options:
+        for param in args.wildcard_options.split():
+            cluster_cmd.append(param)
     logging.debug(cluster_cmd)
     installation_log = open(cluster_path + "/" + 'installation.log', 'w')
     process = subprocess.Popen(cluster_cmd, stdout=installation_log, stderr=installation_log)
@@ -340,6 +346,10 @@ def main():
         '--rosa-flavour',
         type=str,
         help='AWS Flavor to use for infra nodes')
+    parser.add_argument(
+        '--rosa-version',
+        type=str,
+        help='OCP version used to install the cluster')
     parser.add_argument(
         '--aws-profile',
         type=str,


### PR DESCRIPTION
- Add a wildcard parameter to allow passing osde2e and rosa any parameter not considered by the wrapper.
There wont be any validation on this parameter, all the string will be passed to the build_cluster execution

- Add `--version` to rosa wrapper, because using osde2e we can select the version to install on the yaml file, but when using rosa, there wasn't any way to indicate the version to install
