### PR TITLE
add expiration code on rosa installations

### DIFF
--- a/osde2e/README.md
+++ b/osde2e/README.md
@@ -73,7 +73,7 @@ without uploading any information**
 | --batch-size | Number of clusters to create in a batch. If not set it will try and create them all at once. <br>**NOTE**: If not used in conjunction with --delay-between-batch the cluster creation will block at the set batch size until one completes then continue. I.e. if 3 clusters are requested with a batch size of 2. The first two will be requested and then it will block until one of those completes to request the third. | -- |
 | --delay-between-batch | If set, we will wait X seconds between each batch request | -- |
 | --watcher-delay | Delay between each status check in seconds. | 60 |
-| --expire | Minutes until cluster expires and it is deleted by OSD. It sets CLUSTER_EXPIRY_IN_MINUTES var for osde2e | -- |
+| --expire | Minutes until cluster expires and it is automatically deleted. It sets CLUSTER_EXPIRY_IN_MINUTES var for osde2e | -- |
 | --cleanup-clusters | Cleanup any non-error state clusters upon test completion. | False |
 | --user-override | User to set as the owner. <br>**NOTE: this takes precidence over what is provided in the account-config file** | -- |
 | --aws-account-file | AWS account file that provides account,accessKey,secretKey. This file will be looped over as needed to achieve all clusters requested. Example format: <br> ```0009808111,AAAA53YREVPCS111,00019ILbzo+yWU9C5FG5YrnoZC5eBg2111```<br>```0007006111,AAAAUZRL736SW6111,000P/b94AL+LSCzJBWbZCYRuYArF9Zr111```<br>Having AWS_PROFILE variable set will choose which profile to use. | -- |

--- a/rosa/README.md
+++ b/rosa/README.md
@@ -68,7 +68,7 @@ without uploading any information**
 | --batch-size | Number of clusters to create in a batch. If not set it will try and create them all at once. <br>**NOTE**: If not used in conjunction with --delay-between-batch the cluster creation will block at the set batch size until one completes then continue. I.e. if 3 clusters are requested with a batch size of 2. The first two will be requested and then it will block until one of those completes to request the third. | -- |
 | --delay-between-batch | If set, we will wait X seconds between each batch request | -- |
 | --watcher-delay | Delay between each status check in seconds. | 60 |
-| --expire | Minutes until cluster expires and it is deleted by OSD. It sets CLUSTER_EXPIRY_IN_MINUTES var for osde2e | -- |
+| --expire | Minutes until cluster expires and it is automatically deleted. | -- |
 | --cleanup-clusters | Cleanup any non-error state clusters upon test completion. | False |
 | --log-file | File where to write logs. | -- |
 | --log-level | Level of logs to show. | INFO |


### PR DESCRIPTION
OSDE2E was already added the expiration, this is about adding it to rosa, as [blocking issue](https://issues.redhat.com/browse/SDA-3600) is now fixed:


```
2021-05-17 14:37:41.801 INFO rosa-wrapper - _expiration: Extending cluster expiration for 8000 minutes on 1ko0ruqlvgbnjttsc1rhcg4l6s4egfmj
2021-05-17 14:37:41.801 DEBUG rosa-wrapper - _expiration: ['/tmp/30e0cc3b-34e5-48be-bc56-28252f59a14f/rosa', 'edit', 'cluster', '--cluster', '1ko0ruqlvgbnjttsc1rhcg4l6s4egfmj', '--expiration', '8000m']
2021-05-17 14:37:44.324 INFO rosa-wrapper - _expiration: Cluster 1ko0ruqlvgbnjttsc1rhcg4l6s4egfmj will be removed on 8000 minutes, at 2021-05-23 01:57:44 GMT
```