### PR TITLE
Wait 60 seconds extra after all clusters are installed

### DIFF
--- a/hypershift/hosted-wrapper.py
+++ b/hypershift/hosted-wrapper.py
@@ -326,6 +326,8 @@ def _watcher(kubeconfig_location, cluster_name_seed, cluster_count, delay, my_uu
         if installed_clusters == cluster_count:
             with all_clusters_installed:
                 logging.info('All requested clusters on ready status, notifying threads to start e2e-benchmarking processes')
+                logging.info('Waiting 60 extra seconds to allow all cluster installations to finish')
+                time.sleep(60)
                 all_clusters_installed.notify_all()
             break
         elif installed_clusters + other_clusters == cluster_count and installing_clusters == 0:


### PR DESCRIPTION
If watcher detects that all clusters are completed before last hypershift create command, it release the lock before last cluster installation arrives to that lock.

Adding 60 seconds after all clusters are installed allow last installation process to finish
