### PR TITLE
Increase the time until notify threads and move sleep out of the adquiring block

### DIFF
--- a/hypershift/hosted-wrapper.py
+++ b/hypershift/hosted-wrapper.py
@@ -324,10 +324,10 @@ def _watcher(kubeconfig_location, cluster_name_seed, cluster_count, delay, my_uu
         logging.info('   Ready: %d' % installed_clusters)
         logging.info('   Other: %d (%s)' % (other_clusters, other_list))
         if installed_clusters == cluster_count:
+            logging.info('Waiting 5 extra minutes to allow all cluster installations to finish')
+            time.sleep(300)
             with all_clusters_installed:
                 logging.info('All requested clusters on ready status, notifying threads to start e2e-benchmarking processes')
-                logging.info('Waiting 60 extra seconds to allow all cluster installations to finish')
-                time.sleep(60)
                 all_clusters_installed.notify_all()
             break
         elif installed_clusters + other_clusters == cluster_count and installing_clusters == 0:


### PR DESCRIPTION
Sleep was executed after the lock was adquired. moving outside that, we ensure it is executed while any other thread is finishing its execution and arrives to the wait