### PR TITLE
Adding missing reqs for post install script

### DIFF
--- a/tests/test-requirements.txt
+++ b/tests/test-requirements.txt
@@ -1,2 +1,4 @@
 flake8
 elasticsearch
+openshift
+kubernetes


### PR DESCRIPTION
Signed-off-by: Vicente Zepeda Mas <vzepedam@redhat.com>

### Description
When running `post_install_node_config.py` script it fails with missing `kubernetes` and `openshift` requirements.

### Fixes
