### PR TITLE
New features on rosa-hypershift script

### DIFF
--- a/libs/parentParsers.py
+++ b/libs/parentParsers.py
@@ -66,6 +66,11 @@ runnerParser.add_argument(
     type=int,
     help='number of clusters in a batch')
 runnerParser.add_argument(
+    '--delay-between-cleanup',
+    type=int,
+    default=0,
+    help='If set it will wait x seconds between each cluster deletion')
+runnerParser.add_argument(
     '--watcher-delay',
     default=60,
     type=int,

--- a/rosa-hypershift/rosa-hosted-wrapper.py
+++ b/rosa-hypershift/rosa-hosted-wrapper.py
@@ -1118,7 +1118,9 @@ def main():
                 delete_cluster_thread_list.append(thread)
                 thread.start()
                 logging.debug('Number of alive threads %d' % threading.active_count())
-
+                if args.delay_between_cleanup != 0:
+                    logging.info('Waiting %d seconds for deleting the next cluster' % args.delay_between_cleanup)
+                    time.sleep(args.delay_between_cleanup)
         # Wait for active threads to finish
         logging.info('All clusters (%d) requested to be deleted. Waiting for them to finish' % len(delete_cluster_thread_list))
         for t in delete_cluster_thread_list:

--- a/rosa-hypershift/terraform/setup-vpc.tf
+++ b/rosa-hypershift/terraform/setup-vpc.tf
@@ -1,0 +1,49 @@
+# File initially loaded from https://gist.githubusercontent.com/wgordon17/d88501a15204a2f8143bc275a3f64c80/raw/setup-vpc.tf
+
+variable "cluster_name" {
+  type        = string
+  description = "The name of the ROSA cluster to create"
+  default     = "rosa-cluster"
+}
+
+variable "aws_region" {
+  type        = string
+  description = "The region to create the ROSA cluster in"
+  default     = "us-east-2"
+}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "3.14.2"
+  azs     = [data.aws_availability_zones.available.names[0]]
+  name    = "vpc-${var.cluster_name}"
+  cidr    = "10.0.0.0/16"
+
+  private_subnets = ["10.0.1.0/24"]
+  public_subnets  = ["10.0.101.0/24"]
+
+  enable_nat_gateway   = true
+  single_nat_gateway   = true
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+}
+
+output "vpc-id" {
+  value = module.vpc.vpc_id
+}
+
+output "cluster-private-subnet" {
+  value = module.vpc.private_subnets[0]
+}
+
+output "cluster-public-subnet" {
+  value = module.vpc.public_subnets[0]
+}


### PR DESCRIPTION
- one vpc per cluster
- rosa create admin instead of ocm get kubeconfig
- index time of having access to the cluster with cluster-admin on metadata['cluster-admin']
- --workers-wait-time = 0 wont wait for workers to come up for finishing the process
- --delay-between-cleanup to not to delete all clusters at the same time
- --manually-cleanup-aws-iam to delete roles and identity providers
- --service-cluster to collect namespace creation timers both on management cluster and service cluster
