### PR TITLE
Move VPC from using single Nat gateway to One Nat Gateway per AZ

### DIFF
--- a/rosa-hypershift/terraform/setup-vpcs.tf
+++ b/rosa-hypershift/terraform/setup-vpcs.tf
@@ -36,6 +36,8 @@ module "vpc" {
   public_subnets  = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
 
   enable_nat_gateway = true
+  single_nat_gateway = false
+  one_nat_gateway_per_az = true
   enable_dns_hostnames = true
   enable_dns_support   = true
 }


### PR DESCRIPTION
Based on a comment received from AWS, they recomend to use one nat gateway per AZ instead of single nat gateway
