### PR TITLE
forcing cluster workload script

### DIFF
--- a/rosa-hypershift/rosa-hosted-wrapper.py
+++ b/rosa-hypershift/rosa-hosted-wrapper.py
@@ -921,7 +921,12 @@ def _watcher(rosa_cmnd, my_path, cluster_name_seed, cluster_count, delay, my_uui
             logging.info(state_output)
         if error:
             logging.warning('Clusters in error state: %s' % error)
-        if installed_clusters == cluster_count:
+        if os.path.isfile(file_path):
+            with all_clusters_installed:
+                logging.info("User requested the wrapper to start e2e testing by creating e2e file in the test directory")
+                all_clusters_installed.notify_all()
+            break            
+        elif installed_clusters == cluster_count:
             if cluster_load and clusters_with_all_workers == cluster_count:
                 logging.info('All clusters on ready status and all clusters with all workers ready. Waiting 5 extra minutes to allow all cluster installations to arrive notify status')
                 time.sleep(300)
@@ -933,19 +938,9 @@ def _watcher(rosa_cmnd, my_path, cluster_name_seed, cluster_count, delay, my_uui
                 logging.info('All clusters on ready status and no loading process required. Waiting 5 extra minutes to allow all cluster installations to finish.')
                 time.sleep(300)
                 break
-            elif os.path.isfile(file_path):
-                with all_clusters_installed:
-                    logging.info("User requested the wrapper to start e2e testing by creating e2e file in the test directory")
-                    all_clusters_installed.notify_all()
-                break                
             else:
                 logging.info("Waiting %d seconds for next watcher run" % delay)
                 time.sleep(delay)
-        elif os.path.isfile(file_path):
-            with all_clusters_installed:
-                logging.info("User requested the wrapper to start e2e testing by creating e2e file in the test directory")
-                all_clusters_installed.notify_all()
-            break
         else:
             logging.info("Waiting %d seconds for next watcher run" % delay)
             time.sleep(delay)

--- a/rosa-hypershift/rosa-hosted-wrapper.py
+++ b/rosa-hypershift/rosa-hosted-wrapper.py
@@ -933,6 +933,11 @@ def _watcher(rosa_cmnd, my_path, cluster_name_seed, cluster_count, delay, my_uui
                 logging.info('All clusters on ready status and no loading process required. Waiting 5 extra minutes to allow all cluster installations to finish.')
                 time.sleep(300)
                 break
+            elif os.path.isfile(file_path):
+                with all_clusters_installed:
+                    logging.info("User requested the wrapper to start e2e testing by creating e2e file in the test directory")
+                    all_clusters_installed.notify_all()
+                break                
             else:
                 logging.info("Waiting %d seconds for next watcher run" % delay)
                 time.sleep(delay)


### PR DESCRIPTION
### Description
Key to force workload execution without all cluster was missing a case, when all cluster installed but workers are not ready.

### Fixes
